### PR TITLE
feat: 当停止记录终端日志的时候立即关闭文件流

### DIFF
--- a/src/main/kotlin/app/termora/tlog/TerminalLoggerAction.kt
+++ b/src/main/kotlin/app/termora/tlog/TerminalLoggerAction.kt
@@ -23,6 +23,8 @@ class TerminalLoggerAction : AnAction(I18n.getString("termora.terminal-logger"),
     var isRecording = properties.getString("terminal.logger.isRecording")?.toBoolean() ?: false
         private set(value) {
             field = value
+            // firePropertyChange
+            putValue("Recording", value)
             properties.putString("terminal.logger.isRecording", value.toString())
         }
 


### PR DESCRIPTION
### 终端日志

“终端日志” 是全局开关，当开启后所有的 “终端” 窗口日志都会被单独记录到各自的文件中，文件存储在 `~/.termora/terminal/logs/yyyy-MM-dd/${host.name}.HH_mm_ss_SSS.log` 中。

**一旦 “开始记录” 除非手动停止否则记录所有操作记录，日志文件不会自动清除**

### 记录行为
当用户 “开始记录” 时并不会创建日志文件，而是 [VisualTerminal.kt](https://github.com/TermoraDev/termora/blob/1.0.1/src/main/kotlin/app/termora/terminal/VisualTerminal.kt#L52) 发送后会立即创建日志文件。

当用户关闭终端标签页或“停止记录”时，会自动关闭文件流。如果用户再次 “开始记录“ 会重新创建一个日志文件重复此流程

