### PR TITLE
fix: 修复 ESC[?xm 私有模式导致不正常渲染的问题

### DIFF
--- a/src/main/kotlin/app/termora/terminal/ControlSequenceIntroducerProcessor.kt
+++ b/src/main/kotlin/app/termora/terminal/ControlSequenceIntroducerProcessor.kt
@@ -769,6 +769,11 @@ class ControlSequenceIntroducerProcessor(terminal: Terminal, reader: TerminalRea
             args.append("0")
         } else if (args.startsWithMoreMark()) {
             return
+        } else if (args.startsWithQuestionMark()) {
+            if (log.isWarnEnabled) {
+                log.warn("ignore SGR: {}", args)
+            }
+            return
         }
 
         val iterator = args.controlSequences().iterator()


### PR DESCRIPTION
修复 #23 问题。

该问题出现是因为收到了 `ESC[?4m` 私有模式导致的。在 XTerm 协议中 `ESC[4m` 是添加下划线，因为忽略了 `?` 导致意外出现下划线的问题。