### PR TITLE
fix: 修复在同步配置时 “宏” 没有禁用的问题

### DIFF
--- a/src/main/kotlin/app/termora/SettingsOptionsPane.kt
+++ b/src/main/kotlin/app/termora/SettingsOptionsPane.kt
@@ -654,6 +654,7 @@ class SettingsOptionsPane : OptionsPane() {
                 gistTextField.isEnabled = false
                 tokenTextField.isEnabled = false
                 keysCheckBox.isEnabled = false
+                macrosCheckBox.isEnabled = false
                 keywordHighlightsCheckBox.isEnabled = false
                 hostsCheckBox.isEnabled = false
                 domainTextField.isEnabled = false
@@ -685,6 +686,7 @@ class SettingsOptionsPane : OptionsPane() {
                 keysCheckBox.isEnabled = true
                 hostsCheckBox.isEnabled = true
                 typeComboBox.isEnabled = true
+                macrosCheckBox.isEnabled = true
                 gistTextField.isEnabled = true
                 tokenTextField.isEnabled = true
                 domainTextField.isEnabled = true


### PR DESCRIPTION
<img src=https://github.com/user-attachments/assets/82d58a82-7529-4760-af8f-70c3ceff4d9c width=300px />
