### PR TITLE
fix: 修复 SFTP 拖拽单个文件上传失败的问题

### DIFF
--- a/src/main/kotlin/app/termora/transport/FileSystemPanel.kt
+++ b/src/main/kotlin/app/termora/transport/FileSystemPanel.kt
@@ -239,7 +239,7 @@ class FileSystemPanel(
                             }
                         } else {
                             transportPanel.transport(
-                                sourceWorkdir = localFileSystemPanel.workdir,
+                                sourceWorkdir = path.path.parent,
                                 targetWorkdir = workdir,
                                 isSourceDirectory = false,
                                 sourcePath = path.path,

--- a/src/main/kotlin/app/termora/transport/TransportManager.kt
+++ b/src/main/kotlin/app/termora/transport/TransportManager.kt
@@ -102,6 +102,7 @@ class TransportManager : Disposable {
                 }
 
                 if (transport == null) {
+                    needDelay = true
                     continue
                 }
 


### PR DESCRIPTION
在 1.0.1 版本中，如果拖拽单个文件上传会失败。

![image](https://github.com/user-attachments/assets/29739c06-6cf2-49e7-aa5b-c02723938f37)
