### PR TITLE
feat: Windows keyboard shortcut

### DIFF
--- a/src/main/kotlin/app/termora/terminal/panel/TerminalPanel.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalPanel.kt
@@ -47,7 +47,10 @@ class TerminalPanel(val terminal: Terminal, private val ptyConnector: PtyConnect
     /**
      * 键盘事件
      */
-    private val actions = mutableListOf<TerminalPredicateAction>()
+    private val actions = mutableListOf(
+        TerminalWindowsCopyAction(),
+        TerminalWindowsPasteAction(),
+    )
 
 
     /**

--- a/src/main/kotlin/app/termora/terminal/panel/TerminalPanelKeyAdapter.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalPanelKeyAdapter.kt
@@ -52,7 +52,7 @@ class TerminalPanelKeyAdapter(
             return
         }
 
-        if (Character.isISOControl(e.keyChar)) {
+        if (Character.isISOControl(e.keyChar) && isCtrlPressedOnly(e)) {
             terminal.getSelectionModel().clearSelection()
             // 如果不为空表示已经发送过了，所以这里为空的时候再发送
             if (encode.isEmpty()) {

--- a/src/main/kotlin/app/termora/terminal/panel/TerminalWindowsCopyAction.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalWindowsCopyAction.kt
@@ -1,0 +1,22 @@
+package app.termora.terminal.panel
+
+import app.termora.actions.AnActionEvent
+import app.termora.actions.TerminalCopyAction
+import com.formdev.flatlaf.util.SystemInfo
+import org.apache.commons.lang3.StringUtils
+import org.jdesktop.swingx.action.ActionManager
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import javax.swing.KeyStroke
+
+class TerminalWindowsCopyAction : TerminalPredicateAction {
+    private val keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_INSERT, InputEvent.CTRL_DOWN_MASK)
+    override fun actionPerformed(e: KeyEvent) {
+        ActionManager.getInstance().getAction(TerminalCopyAction.COPY)
+            ?.actionPerformed(AnActionEvent(e.source, StringUtils.EMPTY, e))
+    }
+
+    override fun test(keyStroke: KeyStroke, e: KeyEvent): Boolean {
+        return (SystemInfo.isWindows || SystemInfo.isLinux) && keyStroke == this.keyStroke
+    }
+}

--- a/src/main/kotlin/app/termora/terminal/panel/TerminalWindowsPasteAction.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalWindowsPasteAction.kt
@@ -1,0 +1,23 @@
+package app.termora.terminal.panel
+
+import app.termora.actions.AnActionEvent
+import app.termora.actions.TerminalPasteAction
+import com.formdev.flatlaf.util.SystemInfo
+import org.apache.commons.lang3.StringUtils
+import org.jdesktop.swingx.action.ActionManager
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import javax.swing.KeyStroke
+
+class TerminalWindowsPasteAction : TerminalPredicateAction {
+    private val keyStroke = KeyStroke.getKeyStroke(KeyEvent.VK_INSERT, InputEvent.SHIFT_DOWN_MASK)
+
+    override fun actionPerformed(e: KeyEvent) {
+        ActionManager.getInstance().getAction(TerminalPasteAction.PASTE)
+            ?.actionPerformed(AnActionEvent(e.source, StringUtils.EMPTY, e))
+    }
+
+    override fun test(keyStroke: KeyStroke, e: KeyEvent): Boolean {
+        return (SystemInfo.isWindows || SystemInfo.isLinux) && keyStroke == this.keyStroke
+    }
+}


### PR DESCRIPTION
对于终端界面，如果要发送功能键必须按住 `Ctrl` 。例如：`Ctrl + C` 是中断操作，`Ctrl + Shift + C` 是不能发送中断操作的。