### PR TITLE
fix: shortcut keys lead to terminal input

### DIFF
--- a/src/main/kotlin/app/termora/terminal/panel/TerminalPanelKeyAdapter.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalPanelKeyAdapter.kt
@@ -1,5 +1,7 @@
 package app.termora.terminal.panel
 
+import app.termora.keymap.KeyShortcut
+import app.termora.keymap.KeymapManager
 import app.termora.terminal.PtyConnector
 import app.termora.terminal.Terminal
 import com.formdev.flatlaf.util.SystemInfo
@@ -12,8 +14,9 @@ class TerminalPanelKeyAdapter(
     private val terminalPanel: TerminalPanel,
     private val terminal: Terminal,
     private val ptyConnector: PtyConnector
-) :
-    KeyAdapter() {
+) : KeyAdapter() {
+
+    private val activeKeymap get() = KeymapManager.getInstance().getActiveKeymap()
 
     override fun keyTyped(e: KeyEvent) {
         if (Character.isISOControl(e.keyChar)) {
@@ -49,6 +52,11 @@ class TerminalPanelKeyAdapter(
 
         // https://github.com/TermoraDev/termora/issues/52
         if (SystemInfo.isWindows && e.keyCode == KeyEvent.VK_TAB && isCtrlPressedOnly(e)) {
+            return
+        }
+
+        // 如果命中了全局快捷键，那么不处理
+        if (keyStroke.modifiers != 0 && activeKeymap.getActionIds(KeyShortcut(keyStroke)).isNotEmpty()) {
             return
         }
 


### PR DESCRIPTION
在 Windows 情况下当执行 `Ctrl + L/Any key` 时，如果触发了快捷键，那么终端不应该处理这个输入。

<img src=https://github.com/user-attachments/assets/d7822f9c-55f3-4351-8d3e-0e9edbc4928d width=300px />