### PR TITLE
feat: deprecate double-click Shift shortcut

### DIFF
--- a/src/main/kotlin/app/termora/keymap/KeymapManager.kt
+++ b/src/main/kotlin/app/termora/keymap/KeymapManager.kt
@@ -1,9 +1,6 @@
 package app.termora.keymap
 
-import app.termora.ApplicationScope
-import app.termora.Database
-import app.termora.DialogWrapper
-import app.termora.Disposable
+import app.termora.*
 import app.termora.actions.AnActionEvent
 import app.termora.actions.DataProviders
 import app.termora.findeverywhere.FindEverywhereAction
@@ -17,6 +14,7 @@ import java.awt.event.KeyEvent
 import javax.swing.JComponent
 import javax.swing.JDialog
 import javax.swing.KeyStroke
+import javax.swing.SwingUtilities
 
 class KeymapManager private constructor() : Disposable {
 
@@ -32,8 +30,9 @@ class KeymapManager private constructor() : Disposable {
     private val keymapKeyEventDispatcher = KeymapKeyEventDispatcher()
     private val myKeyEventDispatcher = MyKeyEventDispatcher()
     private val database get() = Database.getDatabase()
+    private val properties get() = database.properties
     private val keymaps = linkedMapOf<String, Keymap>()
-    private val activeKeymap get() = database.properties.getString("Keymap.Active")
+    private val activeKeymap get() = properties.getString("Keymap.Active")
     private val keyboardFocusManager by lazy { KeyboardFocusManager.getCurrentKeyboardFocusManager() }
 
     init {
@@ -146,20 +145,39 @@ class KeymapManager private constructor() : Disposable {
 
     }
 
+    @Deprecated(message = "Deprecated")
     private inner class MyKeyEventDispatcher : KeyEventDispatcher {
         // double shift
         private var lastTime = -1L
+        private val findEverywhereAction
+            get() = ActionManager.getInstance().getAction(FindEverywhereAction.FIND_EVERYWHERE)
+        private val deprecatedKey by lazy { "${Application.getVersion()}.FindEverywhereActionDeprecated" }
+
 
         override fun dispatchKeyEvent(e: KeyEvent): Boolean {
             if (e.keyCode == KeyEvent.VK_SHIFT && e.id == KeyEvent.KEY_PRESSED) {
-                val owner = AnActionEvent(e.source, StringUtils.EMPTY, e).getData(DataProviders.TermoraFrame)
-                    ?: return false
+                val evt = AnActionEvent(e.source, StringUtils.EMPTY, e)
+                val owner = evt.getData(DataProviders.TermoraFrame) ?: return false
                 if (keyboardFocusManager.focusedWindow == owner) {
                     val now = System.currentTimeMillis()
                     if (now - 250 < lastTime) {
-                        app.termora.actions.ActionManager.getInstance()
-                            .getAction(FindEverywhereAction.FIND_EVERYWHERE)
-                            ?.actionPerformed(AnActionEvent(e.source, StringUtils.EMPTY, e))
+                        if (!properties.getString(deprecatedKey, "false").toBoolean()) {
+                            properties.putString(deprecatedKey, "true")
+                            val shortcut = getActiveKeymap().getShortcut(FindEverywhereAction.FIND_EVERYWHERE)
+                                .firstOrNull()
+                            if (shortcut == null) {
+                                OptionPane.showMessageDialog(
+                                    owner,
+                                    I18n.getString("termora.find-everywhere.double-shift-deprecated")
+                                )
+                            } else {
+                                OptionPane.showMessageDialog(
+                                    owner,
+                                    I18n.getString("termora.find-everywhere.double-shift-deprecated-instead", shortcut)
+                                )
+                            }
+                        }
+                        SwingUtilities.invokeLater { findEverywhereAction?.actionPerformed(evt) }
                     }
                     lastTime = now
                 }

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -115,6 +115,8 @@ termora.find-everywhere.groups.opened-hosts=Opened hosts
 termora.find-everywhere.groups.tools=Tools
 termora.find-everywhere.groups.settings=${termora.setting}
 termora.find-everywhere.quick-command.local-terminal=Local Terminal
+termora.find-everywhere.double-shift-deprecated=The double-click Shift shortcut will be removed in a future version
+termora.find-everywhere.double-shift-deprecated-instead=${termora.find-everywhere.double-shift-deprecated}, use {0} instead
 
 # Welcome
 termora.welcome.my-hosts=My hosts

--- a/src/main/resources/i18n/messages_zh_CN.properties
+++ b/src/main/resources/i18n/messages_zh_CN.properties
@@ -60,6 +60,8 @@ termora.find-everywhere.groups.opened-hosts=已打开的主机
 termora.find-everywhere.groups.tools=工具
 termora.find-everywhere.groups.settings=${termora.setting}
 termora.find-everywhere.quick-command.local-terminal=本地终端
+termora.find-everywhere.double-shift-deprecated=双击 Shift 快捷键将会在未来的版本中移除
+termora.find-everywhere.double-shift-deprecated-instead=${termora.find-everywhere.double-shift-deprecated}，请使用 {0} 代替
 
 termora.settings.terminal=终端
 termora.settings.terminal.font=字体

--- a/src/main/resources/i18n/messages_zh_TW.properties
+++ b/src/main/resources/i18n/messages_zh_TW.properties
@@ -65,6 +65,8 @@ termora.find-everywhere.groups.opened-hosts=已開啟的主機
 termora.find-everywhere.groups.tools=工具
 termora.find-everywhere.groups.settings=${termora.setting}
 termora.find-everywhere.quick-command.local-terminal=本地端
+termora.find-everywhere.double-shift-deprecated=雙擊 Shift 快捷鍵將會在未來的版本中移除
+termora.find-everywhere.double-shift-deprecated-instead=${termora.find-everywhere.double-shift-deprecated}，請使用 {0} 代替
 
 termora.settings.terminal=終端
 termora.settings.terminal.font=字體


### PR DESCRIPTION
#183

将双击 Shift 快捷键声明为废弃，会在未来的版本中删除。

<img src=https://github.com/user-attachments/assets/e9eced79-be1e-4382-b92b-36357055b92d width=500px />

----

双击 Shift 打开 FindEverywhere 在终端应用中并不合适，用户应该用 `Command + T / Ctrl + T` 或其它自定义快捷键代替。