### PR TITLE
feat: clear terminal screen shortcut

### DIFF
--- a/src/main/kotlin/app/termora/actions/TerminalClearScreenAction.kt
+++ b/src/main/kotlin/app/termora/actions/TerminalClearScreenAction.kt
@@ -1,12 +1,14 @@
 package app.termora.actions
 
+import app.termora.I18n
+
 class TerminalClearScreenAction : AnAction() {
     companion object {
         const val CLEAR_SCREEN = "ClearScreen"
     }
 
     init {
-        putValue(SHORT_DESCRIPTION, "Clear Terminal Buffer")
+        putValue(SHORT_DESCRIPTION, I18n.getString("termora.actions.clear-screen"))
         putValue(ACTION_COMMAND_KEY, CLEAR_SCREEN)
     }
 

--- a/src/main/kotlin/app/termora/keymap/KeymapTableModel.kt
+++ b/src/main/kotlin/app/termora/keymap/KeymapTableModel.kt
@@ -27,6 +27,7 @@ class KeymapTableModel : DefaultTableModel() {
             TerminalZoomOutAction.ZOOM_OUT,
             TerminalZoomResetAction.ZOOM_RESET,
             OpenLocalTerminalAction.LOCAL_TERMINAL,
+            TerminalClearScreenAction.CLEAR_SCREEN,
             FindEverywhereAction.FIND_EVERYWHERE,
             NewWindowAction.NEW_WINDOW,
             TabReconnectAction.RECONNECT_TAB,

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -333,6 +333,7 @@ termora.actions.zoom-reset-terminal=Reset Terminal Zoom
 termora.actions.open-local-terminal=Open Local Terminal
 termora.actions.open-find-everywhere=Open FindEverywhere
 termora.actions.open-new-window=Open new Window
+termora.actions.clear-screen=Clear Terminal Screen
 termora.actions.switch-tab=Switch to specific Tab [1..9]
 
 # Terminal

--- a/src/main/resources/i18n/messages_zh_CN.properties
+++ b/src/main/resources/i18n/messages_zh_CN.properties
@@ -325,6 +325,7 @@ termora.actions.zoom-reset-terminal=重置终端缩放
 termora.actions.open-local-terminal=打开本地终端
 termora.actions.open-find-everywhere=打开全局查找
 termora.actions.open-new-window=打开新窗口
+termora.actions.clear-screen=清除终端屏幕
 termora.actions.switch-tab=切换到特定标签页 [1..9]
 
 # zmodem

--- a/src/main/resources/i18n/messages_zh_TW.properties
+++ b/src/main/resources/i18n/messages_zh_TW.properties
@@ -306,6 +306,7 @@ termora.actions.zoom-reset-terminal=重置終端縮放
 termora.actions.open-local-terminal=開啟本地終端
 termora.actions.open-find-everywhere=開啟全域搜尋
 termora.actions.open-new-window=開啟新視窗
+termora.actions.clear-screen=清除終端機螢幕
 termora.actions.switch-tab=切換到特定分頁 [1..9]
 
 


### PR DESCRIPTION
在 macOS 上执行 `Shift + Command + L` ，在 Windows/Linux 上执行 `Shift + Ctrl + L` 可以清除终端屏幕