### PR TITLE
feat: osc 1337

### DIFF
--- a/src/main/kotlin/app/termora/Host.kt
+++ b/src/main/kotlin/app/termora/Host.kt
@@ -5,6 +5,17 @@ import org.apache.commons.lang3.StringUtils
 import java.util.*
 
 
+fun Map<*, *>.toPropertiesString(): String {
+    val env = StringBuilder()
+    for ((i, e) in entries.withIndex()) {
+        env.append(e.key).append('=').append(e.value)
+        if (i != size - 1) {
+            env.appendLine()
+        }
+    }
+    return env.toString()
+}
+
 fun UUID.toSimpleString(): String {
     return toString().replace("-", StringUtils.EMPTY)
 }

--- a/src/main/kotlin/app/termora/HostTerminalTab.kt
+++ b/src/main/kotlin/app/termora/HostTerminalTab.kt
@@ -1,5 +1,7 @@
 package app.termora
 
+import app.termora.actions.DataProvider
+import app.termora.actions.DataProviders
 import app.termora.terminal.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -12,7 +14,7 @@ abstract class HostTerminalTab(
     val windowScope: WindowScope,
     val host: Host,
     protected val terminal: Terminal = TerminalFactory.getInstance(windowScope).createTerminal()
-) : PropertyTerminalTab() {
+) : PropertyTerminalTab(), DataProvider {
     companion object {
         val Host = DataKey(app.termora.Host::class)
     }
@@ -69,4 +71,11 @@ abstract class HostTerminalTab(
         unread = false
     }
 
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> getData(dataKey: DataKey<T>): T? {
+        if (dataKey == DataProviders.Terminal) {
+            return terminal as T?
+        }
+        return null
+    }
 }

--- a/src/main/kotlin/app/termora/PtyHostTerminalTab.kt
+++ b/src/main/kotlin/app/termora/PtyHostTerminalTab.kt
@@ -1,5 +1,6 @@
 package app.termora
 
+import app.termora.actions.DataProviders
 import app.termora.terminal.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.swing.Swing
@@ -135,4 +136,12 @@ abstract class PtyHostTerminalTab(
     }
 
     abstract suspend fun openPtyConnector(): PtyConnector
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any> getData(dataKey: DataKey<T>): T? {
+        if (dataKey == DataProviders.TerminalPanel) {
+            return terminalPanel as T?
+        }
+        return super.getData(dataKey)
+    }
 }

--- a/src/main/kotlin/app/termora/SFTPPtyTerminalTab.kt
+++ b/src/main/kotlin/app/termora/SFTPPtyTerminalTab.kt
@@ -95,7 +95,14 @@ class SFTPPtyTerminalTab(windowScope: WindowScope, host: Host) : PtyHostTerminal
         // 设置认证信息
         setAuthentication(commands, host)
 
-        commands.add("${host.username}@${host.host}")
+
+        val envs = host.options.envs()
+        if (envs.containsKey("CurrentDir")) {
+            val currentDir = envs.getValue("CurrentDir")
+            commands.add("${host.username}@${host.host}:${currentDir}")
+        } else {
+            commands.add("${host.username}@${host.host}")
+        }
 
         val winSize = terminalPanel.winSize()
         val ptyConnector = ptyConnectorFactory.createPtyConnector(

--- a/src/main/kotlin/app/termora/terminal/DataKey.kt
+++ b/src/main/kotlin/app/termora/terminal/DataKey.kt
@@ -75,6 +75,13 @@ class DataKey<T : Any>(val clazz: KClass<T>) {
         val Workdir = DataKey(String::class)
 
         /**
+         * OSC 1337 CurrentDir
+         *
+         * https://iterm2.com/documentation-escape-codes.html
+         */
+        val CurrentDir = DataKey(String::class)
+
+        /**
          * true: alternate keypad.
          * false: Normal Keypad (DECKPNM)
          */

--- a/src/main/kotlin/app/termora/terminal/OperatingSystemCommandProcessor.kt
+++ b/src/main/kotlin/app/termora/terminal/OperatingSystemCommandProcessor.kt
@@ -4,6 +4,8 @@ import org.apache.commons.codec.binary.Base64
 import org.slf4j.LoggerFactory
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
+import java.io.StringReader
+import java.util.*
 
 class OperatingSystemCommandProcessor(terminal: Terminal, reader: TerminalReader) :
     AbstractProcessor(terminal, reader) {
@@ -82,6 +84,19 @@ class OperatingSystemCommandProcessor(terminal: Terminal, reader: TerminalReader
             8 -> {
                 if (log.isDebugEnabled) {
                     log.debug("Ignore hyperlink OSC: 8")
+                }
+            }
+
+            // https://iterm2.com/documentation-escape-codes.html
+            1337 -> {
+                val properties = Properties()
+                properties.load(StringReader(suffix))
+                if (properties.containsKey("CurrentDir")) {
+                    val currentDir = properties.getProperty("CurrentDir")
+                    terminal.getTerminalModel().setData(DataKey.CurrentDir, currentDir)
+                    if (log.isDebugEnabled) {
+                        log.debug("CurrentDir: $currentDir")
+                    }
                 }
             }
 


### PR DESCRIPTION
## OSC 1337

通过 [OSC 1337](https://iterm2.com/documentation-escape-codes.html) 可以让 Termora 感知到当前工作目录，当进入 `SFTP Command` 可以自动切换到当前 Shell 的工作目录。

要想让 Termora 获取到当前工作目录需要提前配置一些脚本，否则无法正常工作。


### Bash

`~/.bash_profile`:

```bash
export PS1="$PS1\[\e]1337;CurrentDir="'$(pwd)\a\]'
```

### ZSH

`~/.zshrc`:

```bash
precmd () { echo -n "\x1b]1337;CurrentDir=$(pwd)\x07" }
```

### Fish

`~/.config/fish/config.fish`:

```bash
function __termora_working_directory_reporting --on-event fish_prompt
    echo -en "\e]1337;CurrentDir=$PWD\x7"
end
```

注意：当配置完之后，需要重新打开 `SSH` 连接才能生效。
