### PR TITLE
feat: support setting sftp path

### DIFF
--- a/src/main/kotlin/app/termora/Database.kt
+++ b/src/main/kotlin/app/termora/Database.kt
@@ -588,6 +588,12 @@ class Database private constructor(private val env: Environment) : Disposable {
          */
         var editCommand by StringPropertyDelegate(StringUtils.EMPTY)
 
+
+        /**
+         * sftp command
+         */
+        var sftpCommand by StringPropertyDelegate(StringUtils.EMPTY)
+
     }
 
     /**

--- a/src/main/kotlin/app/termora/SFTPPtyTerminalTab.kt
+++ b/src/main/kotlin/app/termora/SFTPPtyTerminalTab.kt
@@ -27,6 +27,7 @@ class SFTPPtyTerminalTab(windowScope: WindowScope, host: Host) : PtyHostTerminal
     private var sshClient: SshClient? = null
     private var sshSession: ClientSession? = null
     private var lastPasswordReporterDataListener: PasswordReporterDataListener? = null
+    private val sftpCommand get() = Database.getDatabase().sftp.sftpCommand
 
     companion object {
         val canSupports by lazy {
@@ -42,9 +43,8 @@ class SFTPPtyTerminalTab(windowScope: WindowScope, host: Host) : PtyHostTerminal
 
     override suspend fun openPtyConnector(): PtyConnector {
 
-
         val useJumpHosts = host.options.jumpHosts.isNotEmpty() || host.proxy.type != ProxyType.No
-        val commands = mutableListOf("sftp")
+        val commands = mutableListOf(StringUtils.defaultIfBlank(sftpCommand, "sftp"))
         var host = this.host
 
         // 如果配置了跳板机或者代理，那么通过 SSH 的端口转发到本地

--- a/src/main/kotlin/app/termora/SettingsOptionsPane.kt
+++ b/src/main/kotlin/app/termora/SettingsOptionsPane.kt
@@ -1297,6 +1297,7 @@ class SettingsOptionsPane : OptionsPane() {
     private inner class SFTPOption : JPanel(BorderLayout()), Option {
 
         val editCommandField = OutlineTextField(255)
+        val sftpCommandField = OutlineTextField(255)
         private val sftp get() = database.sftp
 
         init {
@@ -1311,6 +1312,13 @@ class SettingsOptionsPane : OptionsPane() {
                     sftp.editCommand = editCommandField.text
                 }
             })
+
+
+            sftpCommandField.document.addDocumentListener(object : DocumentAdaptor() {
+                override fun changedUpdate(e: DocumentEvent) {
+                    sftp.sftpCommand = sftpCommandField.text
+                }
+            })
         }
 
 
@@ -1321,7 +1329,14 @@ class SettingsOptionsPane : OptionsPane() {
                 editCommandField.placeholderText = "open -a TextEdit {0}"
             }
 
+            if (SystemInfo.isWindows) {
+                sftpCommandField.placeholderText = "sftp.exe"
+            } else {
+                sftpCommandField.placeholderText = "sftp"
+            }
+
             editCommandField.text = sftp.editCommand
+            sftpCommandField.text = sftp.sftpCommand
         }
 
         override fun getIcon(isSelected: Boolean): Icon {
@@ -1345,6 +1360,8 @@ class SettingsOptionsPane : OptionsPane() {
             val builder = FormBuilder.create().layout(layout).debug(false)
             builder.add("${I18n.getString("termora.settings.sftp.edit-command")}:").xy(1, 1)
             builder.add(editCommandField).xy(3, 1)
+            builder.add("${I18n.getString("termora.tabbed.contextmenu.sftp-command")}:").xy(1, 3)
+            builder.add(sftpCommandField).xy(3, 3)
 
             return builder.build()
 


### PR DESCRIPTION
#263

<img src=https://github.com/user-attachments/assets/53f74956-841e-4cd4-866e-d5e3c1f68fad width=400 px/>
<br/>
<img src=https://github.com/user-attachments/assets/348a83e3-8cd6-49d0-ae76-73d186383260 width=400px />

支持自定义 `sftp` 路径，让用户自定义选择 `sftp` 程序以解决 `Tab` 无法补全的问题。