### PR TITLE
fix: delete leftover files before installing Windows

### DIFF
--- a/src/main/resources/termora.iss
+++ b/src/main/resources/termora.iss
@@ -55,6 +55,10 @@ Source: "{#MySourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdir
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
+[InstallDelete]
+Type: files; Name: "{app}\app\*.jar"
+Type: filesandordirs; Name: "{app}\runtime\*"
+
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall; Check: ShouldPromptStart
 Filename: "{app}\{#MyAppExeName}"; Flags: nowait runhidden; Check: ShouldAutoStart


### PR DESCRIPTION
#557

对于 Windows 安装前，会删除安装目录下的 `{app}\bin\*.jar` 和 `{app}\runtime\*` 文件或文件夹

对于上述规则以外的文件/文件夹不做处理