### PR TITLE
fix: missing remark when importing keys

### DIFF
--- a/src/main/kotlin/app/termora/keymgr/KeyManagerPanel.kt
+++ b/src/main/kotlin/app/termora/keymgr/KeyManagerPanel.kt
@@ -645,9 +645,13 @@ class KeyManagerPanel : JPanel(BorderLayout()) {
                 return
             }
 
+            ohKeyPair = ohKeyPair.copy(
+                name = nameTextField.text,
+                remark = remarkTextField.text,
+            )
+
             if (ohKeyPair.remark.isEmpty()) {
                 ohKeyPair = ohKeyPair.copy(
-                    name = nameTextField.text,
                     remark = "Import on " + DateFormatUtils.format(Date(), I18n.getString("termora.date-format"))
                 )
             }


### PR DESCRIPTION
在导入密钥时，`ohKeyPair.remark`只有在初始化时被赋值，并不会被输入框后续修改过的新值更新。