### PR TITLE
perf: lazy loading `OptionsPane` and `Fonts`

### DIFF
--- a/src/main/kotlin/app/termora/HostDialog.kt
+++ b/src/main/kotlin/app/termora/HostDialog.kt
@@ -25,6 +25,7 @@ class HostDialog(owner: Window, host: Host? = null) : DialogWrapper(owner) {
         isModal = true
         title = I18n.getString("termora.new-host.title")
         setLocationRelativeTo(null)
+        pane.setSelectedIndex(0)
 
         init()
     }

--- a/src/main/kotlin/app/termora/OptionsPane.kt
+++ b/src/main/kotlin/app/termora/OptionsPane.kt
@@ -105,10 +105,6 @@ open class OptionsPane : JPanel(BorderLayout()) {
             }
         }
         tabListModel.addElement(option)
-
-        if (tabList.selectedIndex < 0) {
-            tabList.selectedIndex = 0
-        }
     }
 
     fun removeOption(option: Option) {

--- a/src/main/kotlin/app/termora/OptionsPane.kt
+++ b/src/main/kotlin/app/termora/OptionsPane.kt
@@ -17,6 +17,7 @@ open class OptionsPane : JPanel(BorderLayout()) {
     }
     private val cardLayout = CardLayout()
     private val contentPanel = JPanel(cardLayout)
+    private val loadedComponents = mutableMapOf<String, JComponent>()
 
     init {
         initView()
@@ -103,7 +104,6 @@ open class OptionsPane : JPanel(BorderLayout()) {
                 throw UnsupportedOperationException("Title already exists")
             }
         }
-        contentPanel.add(option.getJComponent(), option.getTitle())
         tabListModel.addElement(option)
 
         if (tabList.selectedIndex < 0) {
@@ -112,7 +112,11 @@ open class OptionsPane : JPanel(BorderLayout()) {
     }
 
     fun removeOption(option: Option) {
-        contentPanel.remove(option.getJComponent())
+        val title = option.getTitle()
+        loadedComponents[title]?.let {
+            contentPanel.remove(it)
+            loadedComponents.remove(title)
+        }
         tabListModel.removeElement(option)
     }
 
@@ -123,7 +127,16 @@ open class OptionsPane : JPanel(BorderLayout()) {
     private fun initEvents() {
         tabList.addListSelectionListener {
             if (tabList.selectedIndex >= 0) {
-                cardLayout.show(contentPanel, tabListModel.get(tabList.selectedIndex).getTitle())
+                val option = tabListModel.get(tabList.selectedIndex)
+                val title = option.getTitle()
+
+                if (!loadedComponents.containsKey(title)) {
+                    val component = option.getJComponent()
+                    loadedComponents[title] = component
+                    contentPanel.add(component, title)
+                }
+
+                cardLayout.show(contentPanel, title)
             }
         }
     }

--- a/src/main/kotlin/app/termora/OptionsPane.kt
+++ b/src/main/kotlin/app/termora/OptionsPane.kt
@@ -134,6 +134,7 @@ open class OptionsPane : JPanel(BorderLayout()) {
                     val component = option.getJComponent()
                     loadedComponents[title] = component
                     contentPanel.add(component, title)
+                    SwingUtilities.updateComponentTreeUI(component)
                 }
 
                 cardLayout.show(contentPanel, title)

--- a/src/main/kotlin/app/termora/SettingsDialog.kt
+++ b/src/main/kotlin/app/termora/SettingsDialog.kt
@@ -3,8 +3,6 @@ package app.termora
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.Window
-import java.awt.event.WindowAdapter
-import java.awt.event.WindowEvent
 import javax.swing.BorderFactory
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -20,8 +18,10 @@ class SettingsDialog(owner: Window) : DialogWrapper(owner) {
         title = I18n.getString("termora.setting")
         setLocationRelativeTo(null)
 
-        init()
+        val index = properties.getString("Settings-SelectedOption")?.toIntOrNull() ?: 0
+        optionsPane.setSelectedIndex(index)
 
+        init()
         initEvents()
     }
 
@@ -29,14 +29,6 @@ class SettingsDialog(owner: Window) : DialogWrapper(owner) {
         Disposer.register(disposable, object : Disposable {
             override fun dispose() {
                 properties.putString("Settings-SelectedOption", optionsPane.getSelectedIndex().toString())
-            }
-        })
-
-        addWindowListener(object : WindowAdapter() {
-            override fun windowActivated(e: WindowEvent) {
-                removeWindowListener(this)
-                val index = properties.getString("Settings-SelectedOption")?.toIntOrNull() ?: return
-                optionsPane.setSelectedIndex(index)
             }
         })
     }

--- a/src/main/kotlin/app/termora/SettingsOptionsPane.kt
+++ b/src/main/kotlin/app/termora/SettingsOptionsPane.kt
@@ -612,12 +612,11 @@ class SettingsOptionsPane : OptionsPane() {
                     if (!fontsLoaded) {
                         val selectedItem = fontComboBox.selectedItem
                         fontComboBox.removeAllItems();
-                        val fonts = linkedSetOf("JetBrains Mono", "Source Code Pro", "Monospaced")
+                        fontComboBox.addItem("JetBrains Mono")
+                        fontComboBox.addItem("Source Code Pro")
+                        fontComboBox.addItem("Monospaced")
                         FontUtils.getAvailableFontFamilyNames().forEach {
-                            if (!fonts.contains(it)) {
-                                fonts.addLast(it)
-                                fontComboBox.addItem(it)
-                            }
+                            fontComboBox.addItem(it)
                         }
                         fontComboBox.selectedItem = selectedItem
                         fontsLoaded = true

--- a/src/main/kotlin/app/termora/SettingsOptionsPane.kt
+++ b/src/main/kotlin/app/termora/SettingsOptionsPane.kt
@@ -604,16 +604,29 @@ class SettingsOptionsPane : OptionsPane() {
 
             shellComboBox.selectedItem = terminalSetting.localShell
 
-            val fonts = linkedSetOf("JetBrains Mono", "Source Code Pro", "Monospaced")
-            FontUtils.getAllFonts().forEach {
-                if (!fonts.contains(it.family)) {
-                    fonts.addLast(it.family)
-                }
-            }
+            fontComboBox.addItem(terminalSetting.font)
+            var fontsLoaded = false
 
-            for (font in fonts) {
-                fontComboBox.addItem(font)
-            }
+            fontComboBox.addPopupMenuListener(object : PopupMenuListener {
+                override fun popupMenuWillBecomeVisible(e: PopupMenuEvent) {
+                    if (!fontsLoaded) {
+                        val selectedItem = fontComboBox.selectedItem
+                        fontComboBox.removeAllItems();
+                        val fonts = linkedSetOf("JetBrains Mono", "Source Code Pro", "Monospaced")
+                        FontUtils.getAvailableFontFamilyNames().forEach {
+                            if (!fonts.contains(it)) {
+                                fonts.addLast(it)
+                                fontComboBox.addItem(it)
+                            }
+                        }
+                        fontComboBox.selectedItem = selectedItem
+                        fontsLoaded = true
+                    }
+                }
+
+                override fun popupMenuWillBecomeInvisible(e: PopupMenuEvent) {}
+                override fun popupMenuCanceled(e: PopupMenuEvent) {}
+            })
 
             fontComboBox.selectedItem = terminalSetting.font
             debugComboBox.selectedItem = terminalSetting.debug


### PR DESCRIPTION
打开`设置`面板时，会一次性加载所有选项，当遇到需要加载很久的面板时，如需要加载非常多的字体的`终端`，会非常影响体验。

这个PR实现了打开面板时选项的懒加载，只有被选中时才会加载的同时，对字体的单选框也实现了懒加载。