### PR TITLE
feat(i18n): add pt-BR translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<a href="./README.zh_CN.md">简体中文</a>
+<a href="./README.zh_CN.md">简体中文</a> | <a href="./README.pt_BR.md">Português (Brasil)</a>
 </div>
 
 # Termora

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -1,0 +1,90 @@
+<div align="center">
+<a href="./README.md">English</a> | <a href="./README.zh_CN.md">简体中文</a>
+</div>
+
+# Termora
+
+**Termora** é um emulador de terminal e cliente SSH multiplataforma, disponível para **Windows, macOS e Linux**.
+
+<div align="center">
+  <img src="docs/readme.png" alt="Termora" />
+</div>
+
+O Termora é desenvolvido utilizando [**Kotlin/JVM**](https://kotlinlang.org/) e implementa parcialmente o [**protocolo de sequência de controle XTerm**](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html). Seu objetivo de longo prazo é alcançar **suporte total a plataformas** (incluindo Android, iOS e iPadOS) via [**Kotlin Multiplatform**](https://kotlinlang.org/docs/multiplatform.html).
+
+## ✨ Recursos
+
+- 🧬 Suporte multiplataforma
+- 🔐 Gerenciador de chaves integrado
+- 🖼️ Encaminhamento X11 (X11 forwarding)
+- 🧑‍💻 Integração com SSH-Agent
+- 💻 Exibição de informações do sistema
+- 📁 Gerenciamento de arquivos SFTP via interface gráfica (GUI)
+- 📊 Monitoramento de uso de GPU Nvidia
+- ⚡ Atalhos de comandos rápidos
+
+## 🚀 Transferência de Arquivos
+
+- Transferências diretas entre servidor A ↔ B
+- Suporte a pastas recursivas
+- Até **6 tarefas de transferência simultâneas**
+
+<div align="center">
+  <img src="docs/transfer.png" alt="Transferência" />
+</div>
+
+## 📝 Edição de Arquivos
+
+- Upload automático após editar e salvar
+- Renomear arquivos e pastas
+- Exclusão rápida de pastas grandes (suporte a `rm -rf`)
+- Edição visual de permissões
+- Criação de novos arquivos e pastas
+
+<div align="center">
+  <img src="docs/transfer-edit.png" alt="Edição de Arquivos" />
+</div>
+
+## 💻 Hosts
+
+- Estrutura hierárquica em árvore, semelhante a pastas
+- Atribuição de tags para hosts individuais
+- Importação de hosts de outras ferramentas
+- Abertura direta com a ferramenta de transferência
+
+<div align="center">
+  <img src="docs/host.png" alt="Gerenciamento de Hosts" />
+</div>
+
+## 🧩 Plugins
+
+- 🌍 Geo: Exibe a geolocalização dos hosts
+- 🔄 Sync: Sincroniza configurações para Gist ou WebDAV
+- 🗂️ WebDAV: Conecta a armazenamentos WebDAV
+- 📝 Editor: Editor de arquivos SFTP integrado
+- 📡 SMB: Conecta ao [SMB](https://pt.wikipedia.org/wiki/Server_Message_Block)
+- ☁️ S3: Conecta ao armazenamento de objetos S3
+- ☁️ Huawei OBS: Conecta ao Huawei Cloud OBS
+- ☁️ Tencent COS: Conecta ao Tencent Cloud COS
+- ☁️ Alibaba OSS: Conecta ao Alibaba Cloud OSS
+- 👉 [Ver todos os plugins...](https://www.termora.app/plugins)
+
+## 📦 Download
+
+- 🧾 [Último Lançamento (Release)](https://github.com/TermoraDev/termora/releases/latest)
+- 🍺 **Homebrew**: `brew install --cask termora`
+- 🔨 **WinGet**: `winget install termora`
+- <img src="https://apps.microsoft.com/assets/icons/logo-16x16.png" alt="microsoft logo"/> <b>Microsoft Store</b>: <a href="https://apps.microsoft.com/store/detail/9NRZBHG43SB9?cid=DevShareMCLPCS">Visite o Termora na Microsoft Store</a>
+
+## 🛠️ Desenvolvimento
+
+Recomendamos o uso do JDK [JetBrainsRuntime](https://github.com/JetBrains/JetBrainsRuntime) para o desenvolvimento.
+
+- Executar localmente: `./gradlew :run`
+
+## 📄 Licença
+
+Este software é distribuído sob um modelo de licença dupla. Você pode escolher uma das seguintes opções:
+
+- **AGPL-3.0**: Use, distribua e modifique o software sob os termos da [AGPL-3.0](https://opensource.org/license/agpl-v3).
+- **Licença Proprietária**: Para uso em código fechado ou comercial, entre em contato com o autor para obter uma licença comercial.

--- a/src/main/resources/i18n/messages_pt_BR.properties
+++ b/src/main/resources/i18n/messages_pt_BR.properties
@@ -1,0 +1,454 @@
+termora.title=Termora
+termora.confirm=OK
+termora.exit=Sair
+termora.cancel=Cancelar
+termora.copy=Copiar
+termora.paste=Colar
+termora.apply=Aplicar
+termora.save=Salvar
+termora.remove=Excluir
+termora.yes=Sim
+termora.no=Não
+termora.date-format=dd/MM/yyyy HH:mm:ss
+termora.finder=Localizador
+termora.folder=Pasta
+termora.file=Arquivo
+termora.explorer=Explorador
+termora.quit-confirm=Finalizar {0}?
+
+termora.regex=Regex
+termora.match-case=Diferenciar maiúsculas/minúsculas
+termora.optional=Opcional
+
+# update
+termora.update.title=Nova versão
+termora.update.update=Atualizar
+
+# Hosts
+termora.host.modified-server-key.title=A IDENTIFICAÇÃO DO HOST [{0}] MUDOU
+termora.host.modified-server-key.thumbprint=Impressão digital (thumbprint) da chave do host
+termora.host.modified-server-key.expected=Esperado
+termora.host.modified-server-key.actual=Atual
+termora.host.modified-server-key.are-you-sure=Tem certeza de que deseja continuar a conexão?
+
+
+# Settings
+termora.setting=Configurações
+
+termora.settings.appearance=Geral
+termora.settings.appearance.theme=Tema
+termora.settings.appearance.layout=Layout
+termora.settings.appearance.layout.screen=Tela
+termora.settings.appearance.layout.fence=Divisão
+termora.settings.appearance.language=Idioma
+termora.settings.appearance.i-want-to-translate=Eu quero traduzir
+termora.settings.appearance.follow-system=Sincronizar com o SO
+termora.settings.appearance.opacity=Opacidade
+termora.settings.appearance.background-running=Execução em segundo plano
+termora.settings.appearance.tab-order=Ordem das Abas
+termora.settings.appearance.confirm-tab-close=Confirmar fechamento de aba
+
+termora.settings.terminal=Terminal
+termora.settings.terminal.font=Fonte
+termora.settings.terminal.fallback-font=Fonte de Reserva
+termora.settings.terminal.size=Tamanho
+termora.settings.terminal.max-rows=Máximo de linhas
+termora.settings.terminal.debug=Modo de depuração
+termora.settings.terminal.beep=Bipe
+termora.settings.terminal.hyperlink=Link
+termora.settings.terminal.select-copy=Copiar ao selecionar
+termora.settings.terminal.right-click=Clique com o botão direito
+termora.settings.terminal.right-click.copy-and-paste=Copiar e Colar
+termora.settings.terminal.right-click.nothing=Nada
+termora.settings.terminal.right-click.copy=${termora.copy}
+termora.settings.terminal.cursor-style=Tipo de cursor
+termora.settings.terminal.cursor-blink=Cursor piscante
+termora.settings.terminal.local-shell=Shell local
+termora.settings.terminal.floating-toolbar=Barra de Ferramentas Flutuante
+termora.settings.terminal.auto-close-tab=Fechar Aba Automaticamente
+termora.settings.terminal.auto-close-tab-description=Fechar automaticamente a aba quando o terminal for desconectado normalmente
+
+
+termora.settings.about=Sobre
+termora.settings.about.author=Autor
+termora.settings.about.source=Código-fonte
+termora.settings.about.issue=Problemas (Issues)
+termora.settings.about.third-party=Terceiros
+termora.settings.about.termora=<html><b>${termora.title}</b> ({0}) é um cliente SSH multiplataforma. </html>
+
+termora.settings.plugin=Plugins
+termora.settings.plugin.install=Instalar
+termora.settings.plugin.installed=Instalado
+termora.settings.plugin.marketplace=Marketplace
+termora.settings.plugin.uninstall=Desinstalar
+termora.settings.plugin.uninstall-confirm=Tem certeza de que deseja desinstalar <b>{0}</b>?
+termora.settings.plugin.uninstall-failed=Falha na desinstalação
+termora.settings.plugin.install-failed=Falha na instalação, tente novamente mais tarde
+termora.settings.plugin.install-from-disk=Instalar Plugin do Disco...
+termora.settings.plugin.manage-plugin-repository=Gerenciar Repositório de Plugins...
+termora.settings.plugin.install-from-disk-warning=O plugin <b>{0}</b> terá acesso a todos os seus dados. Tem certeza de que deseja instalá-lo?
+termora.settings.plugin.not-compatible=O plugin <b>{0}</b> é incompatível com a versão atual. Por favor, reinstale <b>{0}</b>
+
+termora.settings.account=Conta
+termora.settings.account.login=Entrar
+termora.settings.account.server=Servidor
+termora.settings.account.wait-login=Aguardando login no navegador padrão...
+termora.settings.account.locally=localmente
+termora.settings.account.lifetime=Vitalício
+termora.settings.account.upgrade=Upgrade
+termora.settings.account.verify=Verificar
+termora.settings.account.subscription=Assinatura
+termora.settings.account.valid-to=Válido até
+termora.settings.account.synchronization-on=Sincronização ativada
+termora.settings.account.sync-now=Sincronizar agora
+termora.settings.account.logout=Sair
+termora.settings.account.logout-confirm=Tem certeza de que deseja sair?
+termora.settings.account.unsynced-logout-confirm=Não sincronizado. Tem certeza de que deseja sair?
+termora.settings.account.server-singapore=Cingapura
+termora.settings.account.server-china=China Continental
+termora.settings.account.new-server=Novo Servidor
+termora.settings.account.deploy-server=Implantar
+termora.settings.account.login-failed=Falha no login, tente novamente mais tarde
+
+
+termora.settings.keymap=Atalhos de Teclado
+termora.settings.keymap.shortcut=Atalho
+termora.settings.keymap.action=Ação
+termora.settings.keymap.already-exists=O atalho [{0}] já está em uso por [{1}]
+termora.settings.keymap.question=Selecione uma linha e pressione a tecla <font color=rgb({0},{1},{2})> ⌫ (Backspace)</font> para remover o atalho
+
+termora.settings.sftp.edit-command=Comando de Edição
+termora.settings.sftp.db-click-behavior=Clique duplo
+termora.settings.sftp.fixed-tab=Aba fixa
+termora.settings.sftp.default-directory=Diretório Padrão
+termora.settings.sftp.preserve-time=Preservar data de modificação original do arquivo
+
+
+termora.settings.restart.title=Reiniciar
+termora.settings.restart.message=As alterações terão efeito após reiniciar o aplicativo
+termora.settings.restart.manually=Por favor, reinicie o software manualmente
+
+# Find everywhere
+termora.find-everywhere=Busca Global
+termora.find-everywhere.search-for-something=Procurar por algo...
+termora.find-everywhere.groups.quick-actions=Ações rápidas
+termora.find-everywhere.groups.open-new-hosts=Abrir novo host
+termora.find-everywhere.groups.opened-hosts=Hosts abertos
+termora.find-everywhere.groups.tools=Ferramentas
+termora.find-everywhere.groups.settings=${termora.setting}
+termora.find-everywhere.quick-command.local-terminal=Terminal Local
+
+# Welcome
+termora.welcome.my-hosts=Meus hosts
+termora.welcome.toggle-sidebar=Alternar Barra Lateral
+termora.welcome.contextmenu.connect=Conectar
+termora.welcome.contextmenu.connect-with=Conectar com
+termora.welcome.contextmenu.open-in-new-window=${termora.tabbed.contextmenu.open-in-new-window}
+termora.welcome.contextmenu.refresh=${termora.transport.table.contextmenu.refresh}
+termora.welcome.contextmenu.copy=${termora.copy}
+termora.welcome.contextmenu.remove=${termora.remove}
+termora.welcome.contextmenu.rename=Renomear
+termora.welcome.contextmenu.expand-all=Expandir tudo
+termora.welcome.contextmenu.collapse-all=Recolher tudo
+termora.welcome.contextmenu.new=Novo
+termora.welcome.contextmenu.import=${termora.keymgr.import}
+termora.welcome.contextmenu.new.folder=${termora.folder}
+termora.welcome.contextmenu.new.host=Host
+termora.welcome.contextmenu.new.folder.name=Nova Pasta
+termora.welcome.contextmenu.property=Propriedades
+termora.welcome.contextmenu.show=Mostrar
+termora.welcome.contextmenu.show.more-info=Mais informações
+termora.welcome.contextmenu.show.tags=${termora.tag}
+termora.welcome.contextmenu.download=Download
+termora.welcome.contextmenu.import.csv.download-template=Deseja importar ou baixar o modelo?
+termora.welcome.contextmenu.import.csv.download-template-done=Modelo baixado com sucesso
+termora.welcome.contextmenu.import.csv.download-template-done-open-folder=Modelo baixado com sucesso. Deseja abrir a pasta?
+termora.welcome.contextmenu.import.xshell-folder-empty=A pasta não contém arquivos *.xsh. Por favor, selecione o diretório correto de Sessões do Xshell
+termora.welcome.contextmenu.import.finalshell-folder-empty=A pasta não contém arquivos *_connect_config.json. Por favor, selecione o diretório correto do FinalShell
+
+# New Host
+termora.new-host.title=Criar um novo host
+termora.new-host.general=Geral
+termora.new-host.general.name=Nome
+termora.new-host.general.protocol=Protocolo
+termora.new-host.general.host=Host
+termora.new-host.general.port=Porta
+termora.new-host.general.username=Usuário
+termora.new-host.general.authentication=Autenticação
+termora.new-host.general.password=Senha
+termora.new-host.general.remark=Comentário
+termora.new-host.general.remember=Lembrar
+
+termora.new-host.proxy=Proxy
+
+termora.new-host.terminal=${termora.settings.terminal}
+termora.new-host.terminal.encoding=Codificação
+termora.new-host.terminal.backspace=Backspace
+termora.new-host.terminal.character-mode=Um caractere por vez
+termora.new-host.terminal.heartbeat-interval=Intervalo de Heartbeat
+termora.new-host.terminal.timeout=Tempo limite
+termora.new-host.terminal.startup-commands=Comando de Inicialização
+termora.new-host.terminal.alt-modifier=Modificador Alt
+termora.new-host.terminal.alt-modifier.eight-bit=Caracteres de 8 bits
+termora.new-host.terminal.alt-modifier.by-esc=Caracteres precedidos por ESC
+termora.new-host.terminal.env=Ambiente
+termora.new-host.terminal.login-scripts=Scripts de Login
+termora.new-host.terminal.expect=Expect
+termora.new-host.terminal.send=Send
+
+termora.new-host.serial=Serial
+termora.new-host.serial.port=Porta
+termora.new-host.serial.baud-rate=Baud rate
+termora.new-host.serial.data-bits=Data bits
+termora.new-host.serial.parity=Paridade
+termora.new-host.serial.stop-bits=Stop bits
+termora.new-host.serial.flow-control=Controle de fluxo
+
+termora.new-host.tunneling=Túnel
+termora.new-host.tunneling.table.name=Nome
+termora.new-host.tunneling.table.type=Tipo
+termora.new-host.tunneling.table.source=Origem
+termora.new-host.tunneling.table.destination=Destino
+termora.new-host.tunneling.add=Adicionar
+termora.new-host.tunneling.edit=${termora.keymgr.edit}
+termora.new-host.tunneling.delete=${termora.remove}
+
+termora.new-host.rdp.desktop-placeholder=Tela cheia padrão (ex: 1920×1080)
+termora.new-host.rdp.resolution=Resolução
+
+
+termora.new-host.wsl.distribution=Nome da Distro
+
+termora.new-host.test-connection=Testar Conexão
+termora.new-host.test-connection-successful=Conexão bem-sucedida
+
+
+termora.new-host.jump-hosts=Servidores de Salto
+
+# Key manager
+termora.keymgr.title=Gerenciador de Chaves
+termora.keymgr.my-keys=Minhas chaves
+termora.keymgr.generate=Gerar
+termora.keymgr.import=Importar
+termora.keymgr.export=Exportar
+termora.keymgr.edit=Editar
+termora.keymgr.private-key=Chave Privada
+termora.keymgr.delete-warning=Tem certeza de que deseja excluir?
+termora.keymgr.table.name=Nome
+termora.keymgr.table.type=Tipo
+termora.keymgr.table.length=Comprimento
+termora.keymgr.table.remark=Descrição
+termora.keymgr.export-done=A exportação foi concluída com sucesso
+termora.keymgr.export-done-open-folder=A exportação foi concluída com sucesso. Deseja abrir a pasta?
+
+termora.keymgr.ssh-copy-id.number=Número de hosts [{0}]    Número de chaves públicas [{1}]
+termora.keymgr.ssh-copy-id.successful=${termora.terminal.copied}
+termora.keymgr.ssh-copy-id.failed=Falha ao copiar
+termora.keymgr.ssh-copy-id.end=Fim da cópia da chave pública
+
+
+# Tabbed
+termora.tabbed.contextmenu.rename=Renomear
+termora.tabbed.contextmenu.select-host=Selecionar Host
+termora.tabbed.contextmenu.sftp-command=Comando SFTP
+termora.tabbed.contextmenu.sftp-not-install=Programa SFTP não encontrado, instale e tente novamente
+termora.tabbed.contextmenu.clone=Clonar
+termora.tabbed.contextmenu.clone-session=Clonar Sessão
+termora.tabbed.contextmenu.open-in-new-window=Abrir em Nova Janela
+termora.tabbed.contextmenu.close=Fechar
+termora.tabbed.contextmenu.close-other-tabs=Fechar Outras Abas
+termora.tabbed.contextmenu.close-all-tabs=Fechar Todas as Abas
+termora.tabbed.contextmenu.reconnect=Reconectar
+termora.tabbed.local-tab.close-prompt=Deseja encerrar um processo em execução neste terminal?
+termora.tabbed.tab.close-prompt=Tem certeza de que deseja fechar esta aba?
+
+# Terminal logger
+termora.terminal-logger=Log do Terminal
+termora.terminal-logger.start-recording=Iniciar Gravação
+termora.terminal-logger.plain-text=Texto sem formatação
+termora.terminal-logger.styled-text=Texto formatado
+termora.terminal-logger.stop-recording=Parar Gravação
+termora.terminal-logger.open-log-viewer=Abrir Visualizador de Log
+termora.terminal-logger.open-in-folder=Abrir em {0}
+
+
+# Highlight
+termora.highlight=Conjuntos de Realce
+termora.highlight.default-set=Conjunto Padrão
+termora.highlight.text-color=Cor do Texto
+termora.highlight.background-color=Cor do Fundo
+termora.highlight.keyword=Palavra-chave
+termora.highlight.my-keyword=Minha Palavra-chave
+termora.highlight.preview=Visualização
+termora.highlight.description=Descrição
+termora.highlight.bold=Negrito
+termora.highlight.italic=Itálico
+termora.highlight.underline=Sublinhado
+termora.highlight.line-through=Tachado
+
+# tag
+termora.tag=Tags
+termora.tag.my-tags=Minhas tags
+termora.tag.manage-tags=Gerenciar tags
+
+# Macro
+termora.macro=Macros
+termora.macro.start-recording=Iniciar Gravação
+termora.macro.stop-recording=Parar Gravação
+termora.macro.playback=Reproduzir
+termora.macro.manager=Gerenciar Macros
+termora.macro.run=Executar
+
+# Snippets
+termora.snippet=Snippet
+termora.snippet.title=Snippets
+
+# Tools
+termora.tools.multiple=Enviar comando para as sessões da janela atual
+
+# Transport
+termora.transport.local=Local
+termora.transport.file-already-exists=O arquivo {0} já existe
+
+
+termora.transport.toolbar.prev=Voltar
+termora.transport.toolbar.home=Pasta Pessoal (Home)
+termora.transport.toolbar.next=Avançar
+termora.transport.toolbar.parent=Pasta Superior
+termora.transport.toolbar.show-hide=Mostrar/Ocultar Pastas
+termora.transport.toolbar.refresh=Atualizar Pasta
+
+termora.transport.bookmarks=Gerenciador de Favoritos
+termora.transport.bookmarks.up=Para cima
+termora.transport.bookmarks.down=Para baixo
+
+termora.transport.table.filename=Nome do arquivo
+termora.transport.table.type=Tipo
+termora.transport.table.type.symbolic-link=Link Simbólico
+termora.transport.table.size=Tamanho
+termora.transport.table.modified-time=Modificado
+termora.transport.table.permissions=Permissões
+termora.transport.table.owner=Proprietário
+
+# contextmenu
+termora.transport.table.contextmenu.transfer=Transferir
+termora.transport.table.contextmenu.edit=${termora.keymgr.edit}
+termora.transport.table.contextmenu.copy-path=Copiar Caminho
+termora.transport.table.contextmenu.open-in-folder=Abrir em {0}
+termora.transport.table.contextmenu.rename=${termora.welcome.contextmenu.rename}
+termora.transport.table.contextmenu.delete=${termora.remove}
+termora.transport.table.contextmenu.rm-warning=Usar o comando rm -rf para excluir um arquivo é muito perigoso
+termora.transport.table.contextmenu.change-permissions=Alterar Permissões...
+termora.transport.table.contextmenu.refresh=Atualizar
+termora.transport.table.contextmenu.compress=Compactar
+termora.transport.table.contextmenu.extract=Extrair
+termora.transport.table.contextmenu.extract.here=Extrair aqui
+termora.transport.table.contextmenu.extract.single=Extrair para {0}\\
+termora.transport.table.contextmenu.extract.multi=Extrair para *\\*
+termora.transport.table.contextmenu.new=${termora.welcome.contextmenu.new}
+termora.transport.table.contextmenu.new.folder=${termora.welcome.contextmenu.new.folder.name}
+termora.transport.table.contextmenu.new.file=Novo Arquivo
+
+# Permission
+termora.transport.permissions=Alterar Permissões
+termora.transport.permissions.file-folder-permissions=Permissões de Arquivo/Pasta
+termora.transport.permissions.read=Leitura
+termora.transport.permissions.write=Escrita
+termora.transport.permissions.execute=Execução
+termora.transport.permissions.owner=Proprietário
+termora.transport.permissions.group=Grupo
+termora.transport.permissions.others=Outros
+termora.transport.permissions.include-subfolder=Incluir subdiretórios
+
+termora.transport.sftp=Transferência
+termora.transport.sftp.retry=Repetir
+termora.transport.sftp.select-another-host=Selecionar outro host
+termora.transport.sftp.select-host=Selecionar host
+termora.transport.sftp.connecting=Conectando...
+termora.transport.sftp.closed=A conexão foi fechada
+termora.transport.sftp.close-tab=A transferência ainda está ativa. Tem certeza de que deseja remover todas as tarefas e fechar esta sessão?
+termora.transport.sftp.close-tab-has-active-session=A sessão ainda está ativa. Deseja fechar todas as sessões?
+termora.transport.sftp.status.transporting=Em progresso
+termora.transport.sftp.status.deleting=Excluindo
+termora.transport.sftp.status.waiting=Aguardando
+termora.transport.sftp.status.done=Concluído
+termora.transport.sftp.status.failed=Falhou
+
+termora.transport.sftp.already-exists.message1=Esta pasta já contém um objeto com o nome abaixo
+termora.transport.sftp.already-exists.message2=Selecione uma ação
+termora.transport.sftp.already-exists.overwrite=Sobrescrever
+termora.transport.sftp.already-exists.append=Anexar (Append)
+termora.transport.sftp.already-exists.skip=Pular
+termora.transport.sftp.already-exists.apply-all=Aplicar a todos
+termora.transport.sftp.already-exists.name=Nome
+termora.transport.sftp.already-exists.destination=Destino
+termora.transport.sftp.already-exists.source=Origem
+termora.transport.sftp.already-exists.actions=Ações
+
+
+# transport job
+termora.transport.jobs.table.name=Nome
+termora.transport.jobs.table.status=Status
+termora.transport.jobs.table.progress=Progresso
+termora.transport.jobs.table.size=Tamanho
+termora.transport.jobs.table.source-path=Caminho de Origem
+termora.transport.jobs.table.target-path=Caminho de Destino
+termora.transport.jobs.table.speed=Velocidade
+termora.transport.jobs.table.estimated-time=Tempo estimado
+termora.transport.jobs.table.estimated-time-days-format={0}d {1}h {2}m {3}s
+termora.transport.jobs.table.estimated-time-hours-format={0}h {1}m {2}s
+termora.transport.jobs.table.estimated-time-minutes-format={0}m {1}s
+termora.transport.jobs.table.estimated-time-seconds-format={0}s
+
+termora.transport.jobs.contextmenu.delete=${termora.remove}
+termora.transport.jobs.contextmenu.delete-all=Excluir Todos
+
+# ToolBar
+termora.toolbar.customize-toolbar=Personalizar Barra de Ferramentas...
+
+
+# Actions
+termora.actions.copy-from-terminal=Copiar do Terminal
+termora.actions.focus-mode=Modo Foco
+termora.actions.paste-to-terminal=Colar no Terminal
+termora.actions.select-all-in-terminal=Selecionar Tudo no Terminal
+termora.actions.open-terminal-find=Abrir Busca no Terminal
+termora.actions.close-tab=Fechar Aba
+termora.actions.zoom-in-terminal=Aumentar Zoom do Terminal
+termora.actions.zoom-out-terminal=Diminuir Zoom do Terminal
+termora.actions.zoom-reset-terminal=Redefinir Zoom do Terminal
+termora.actions.open-local-terminal=Abrir Terminal Local
+termora.actions.quick-connect=Conexão Rápida
+termora.actions.open-find-everywhere=Abrir Busca Global
+termora.actions.open-new-window=Abrir nova Janela
+termora.actions.clear-screen=Limpar Tela do Terminal
+termora.actions.open-sftp-command=Abrir Comando SFTP
+termora.actions.switch-tab=Alternar para Aba específica [1..9]
+
+# Terminal
+termora.terminal.size=Tamanho: {0} x {1}
+termora.terminal.copied=Copiado
+termora.terminal.channel-disconnected=O canal foi desconectado.\u0020
+termora.terminal.channel-reconnect=Digite {0} para reconectar.
+
+# protocol
+termora.protocol.not-supported=O protocolo {0} não é suportado, você pode precisar instalar um plugin
+
+# Visual Window
+termora.visual-window.system-information=Informações do sistema
+termora.visual-window.system-information.mem=Mem
+termora.visual-window.system-information.swap=Swap
+termora.visual-window.system-information.filesystem=Sist. Arquivos
+termora.visual-window.system-information.used-total=Usado / Total
+termora.visual-window.toggle-window=Alternar janela
+termora.visual-window.transport.question=Mais recursos
+
+
+termora.visual-window.nvidia-smi=NVIDIA SMI
+
+
+termora.floating-toolbar.close-in-current-tab=Fechar na aba atual
+
+
+# zmodem
+termora.addons.zmodem.skip=PULAR


### PR DESCRIPTION
## Description
This PR adds the Portuguese (Brazil) translation for Termora.

### Changes:
- Added `messages_pt_BR.properties` in `src/main/resources/i18n/`.
- Created `README.pt_BR.md` with the full translation of the main documentation.
- Updated the main `README.md` to include a link to the Portuguese version.

I have ensured that the translation follows the existing terminology used in the project and maintained the original formatting for variables like `{0}` and references like `${termora.copy}`.

## Checklist
- [x] Translation file named correctly (`messages_pt_BR.properties`).
- [x] README translation created and linked.
- [x] Used UTF-8 encoding for the properties file.