### PR TITLE
fix: send mouse sequence instead of arrow keys when mouse tracking is active

### DIFF
--- a/src/main/kotlin/app/termora/terminal/panel/TerminalPanelMouseTrackingAdapter.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalPanelMouseTrackingAdapter.kt
@@ -65,7 +65,12 @@ class TerminalPanelMouseTrackingAdapter(
     }
 
     override fun mouseWheelMoved(e: MouseWheelEvent) {
-        if (this.shouldSendMouseData || terminalModel.isAlternateScreenBuffer()) {
+        if (shouldSendMouseData) {
+            // Application requested mouse tracking (e.g. tmux with mouse on), send raw mouse sequence
+            val p = terminalPanel.pointToPosition(e.point)
+            sendMouseEvent(p, AWTTerminalMouseEvent(e), TerminalMouseEventType.Pressed)
+        } else if (terminalModel.isAlternateScreenBuffer()) {
+            // Alternate screen without mouse tracking (e.g. plain vim), fall back to arrow keys
             val unitsToScroll = e.unitsToScroll
             val encode = terminal.getKeyEncoder()
                 .encode(TerminalKeyEvent(if (e.wheelRotation < 0) KeyEvent.VK_UP else KeyEvent.VK_DOWN))


### PR DESCRIPTION
## 问题描述

Fix #1442 ：在 tmux 开启鼠标模式（`set -g mouse on`）后，Termora 在交替屏幕（Alternate Screen Buffer）中滚动鼠标滚轮时，错误地向 tmux 发送方向键序列（`\e[A` / `\e[B`），而非正确的 XTerm 鼠标序列（如 SGR 格式 `\e[<64;x;yM`）。

## 根本原因

`TerminalPanelMouseTrackingAdapter.kt` 中的 `mouseWheelMoved` 方法将两种完全不同的场景用同一逻辑处理：

```kotlin
// 修复前（有 bug）
override fun mouseWheelMoved(e: MouseWheelEvent) {
    if (this.shouldSendMouseData || terminalModel.isAlternateScreenBuffer()) {
        // 无论是否有鼠标追踪，都发送方向键 —— 错误！
        val encode = terminal.getKeyEncoder()
            .encode(TerminalKeyEvent(if (e.wheelRotation < 0) KeyEvent.VK_UP else KeyEvent.VK_DOWN))
        ...
    }
}
```

当 `shouldSendMouseData == true`（应用通过 `CSI ? 1000h` / `1002h` / `1003h` 请求了鼠标追踪）时，终端应发送原始鼠标序列，而不是方向键。

## 修复方案

将单一的 `if` 拆分为有优先级的 `if / else if`：

```kotlin
// 修复后
override fun mouseWheelMoved(e: MouseWheelEvent) {
    if (shouldSendMouseData) {
        // 应用请求了鼠标追踪（如 tmux mouse on），发送原始鼠标序列
        val p = terminalPanel.pointToPosition(e.point)
        sendMouseEvent(p, AWTTerminalMouseEvent(e), TerminalMouseEventType.Pressed)
    } else if (terminalModel.isAlternateScreenBuffer()) {
        // 交替屏幕但无鼠标追踪（如普通 vim），降级为方向键
        val unitsToScroll = e.unitsToScroll
        val encode = terminal.getKeyEncoder()
            .encode(TerminalKeyEvent(if (e.wheelRotation < 0) KeyEvent.VK_UP else KeyEvent.VK_DOWN))
        if (encode.isBlank()) return
        val bytes = encode.toByteArray(writer.getCharset())
        for (i in 0 until abs(unitsToScroll)) {
            writer.write(TerminalWriter.WriteRequest.fromBytes(bytes))
        }
    }
}
```

## 行为对照表

| 条件 | 修复前 | 修复后 |
|------|--------|--------|
| `shouldSendMouseData == true`（tmux mouse on） | 发送方向键 | 发送原始鼠标序列 |
| 交替屏幕 + 无鼠标追踪（普通 vim） | 发送方向键 | 发送方向键 |

## 测试步骤

1. 连接至远程服务器
2. 启动 tmux：`tmux new-session`
3. 开启鼠标模式：`tmux set -g mouse on`
4. 在 tmux 窗格中上下滚动鼠标滚轮
5. 期望：tmux 正确处理滚动（历史记录可正常滚动）
6. 打开普通 vim（无鼠标追踪），滚动鼠标滚轮
7. 期望：方向键 fallback 依然正常工作

## 改动文件

- `src/main/kotlin/app/termora/terminal/panel/TerminalPanelMouseTrackingAdapter.kt`