### PR TITLE
feat: add command history visual window

### DIFF
--- a/src/main/kotlin/app/termora/Icons.kt
+++ b/src/main/kotlin/app/termora/Icons.kt
@@ -169,4 +169,5 @@ object Icons {
     val moreHorizontal by lazy { DynamicIcon("icons/moreHorizontal.svg", "icons/moreHorizontal_dark.svg") }
     val springCloudFileSet by lazy { DynamicIcon("icons/springCloudFileSet.svg", "icons/springCloudFileSet_dark.svg") }
     val dav by lazy { DynamicIcon("icons/dav.svg", "icons/dav_dark.svg") }
+    val history by lazy { DynamicIcon("icons/history.svg", "icons/history_dark.svg") }
 }

--- a/src/main/kotlin/app/termora/plugin/internal/local/LocalTerminalTab.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/local/LocalTerminalTab.kt
@@ -25,7 +25,7 @@ class LocalTerminalTab(windowScope: WindowScope, host: Host) :
 
     override suspend fun openPtyConnector(): PtyConnector {
         val winSize = terminalPanel.winSize()
-        val ptyConnector = PtyConnectorFactory.Companion.getInstance().createPtyConnector(
+        val ptyConnector = PtyConnectorFactory.getInstance().createPtyConnector(
             winSize.rows, winSize.cols,
             host.options.envs(),
             Charsets.toCharset(host.options.encoding, StandardCharsets.UTF_8),
@@ -77,5 +77,9 @@ class LocalTerminalTab(windowScope: WindowScope, host: Host) :
             if (p is PtyConnectorDelegate) p = p.ptyConnector
         }
         return null
+    }
+
+    override fun beforeClose() {
+        terminalPanel.storeVisualWindows(host.id)
     }
 }

--- a/src/main/kotlin/app/termora/terminal/panel/FloatingToolbarPanel.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/FloatingToolbarPanel.kt
@@ -7,6 +7,7 @@ import app.termora.actions.DataProvider
 import app.termora.actions.DataProviders
 import app.termora.database.DatabaseManager
 import app.termora.plugin.ExtensionManager
+import app.termora.plugin.internal.local.LocalTerminalTab
 import app.termora.plugin.internal.ssh.SSHTerminalTab
 import app.termora.terminal.DataKey
 import app.termora.terminal.panel.vw.VisualWindowManager
@@ -155,16 +156,17 @@ class FloatingToolbarPanel : FlatToolBar(), Disposable {
     @Suppress("UNCHECKED_CAST")
     private fun resumeVisualWindows() {
         val tab = event.getData(DataProviders.TerminalTab) ?: return
-        if (tab !is SSHTerminalTab) return
-        val terminalPanel = tab.getData(DataProviders.TerminalPanel) ?: return
-        terminalPanel.resumeVisualWindows(tab.host.id, object : DataProvider {
-            override fun <T : Any> getData(dataKey: DataKey<T>): T? {
-                if (dataKey == DataProviders.TerminalTab) {
-                    return tab as T
+        if (tab is SSHTerminalTab || tab is LocalTerminalTab) {
+            val terminalPanel = tab.getData(DataProviders.TerminalPanel) ?: return
+            terminalPanel.resumeVisualWindows(tab.host.id, object : DataProvider {
+                override fun <T : Any> getData(dataKey: DataKey<T>): T? {
+                    if (dataKey == DataProviders.TerminalTab) {
+                        return tab as T
+                    }
+                    return super.getData(dataKey)
                 }
-                return super.getData(dataKey)
-            }
-        })
+            })
+        }
     }
 
     private fun createButton(

--- a/src/main/kotlin/app/termora/terminal/panel/TerminalPanel.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalPanel.kt
@@ -766,6 +766,13 @@ class TerminalPanel(val tab: TerminalTab?, val terminal: Terminal, private val w
                         this
                     )
                 )
+            } else if (name == "CommandHistory") {
+                addVisualWindow(
+                    CommandHistoryVisualWindow(
+                        dataProvider.getData(DataProviders.TerminalTab) as HostTerminalTab,
+                        this
+                    )
+                )
             }
         }
     }

--- a/src/main/kotlin/app/termora/terminal/panel/vw/CommandHistoryVisualWindow.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/vw/CommandHistoryVisualWindow.kt
@@ -1,0 +1,280 @@
+package app.termora.terminal.panel.vw
+
+import app.termora.*
+import app.termora.actions.DataProviders
+import app.termora.database.DatabaseManager
+import app.termora.plugin.internal.local.LocalTerminalTab
+import app.termora.plugin.internal.ssh.SSHTerminalTab
+import app.termora.plugin.internal.ssh.SshClients
+import app.termora.terminal.panel.TerminalWriter
+import com.formdev.flatlaf.extras.components.FlatTextField
+import com.jgoodies.forms.builder.FormBuilder
+import com.jgoodies.forms.layout.FormLayout
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.swing.Swing
+import kotlinx.coroutines.withContext
+import org.apache.commons.lang3.StringUtils
+import org.apache.commons.lang3.SystemUtils
+import org.slf4j.LoggerFactory
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.io.File
+import java.util.*
+import javax.swing.*
+
+
+internal open class CommandHistoryVisualWindow(
+    private val tab: HostTerminalTab,
+    visualWindowManager: VisualWindowManager
+) : VisualWindowPanel("CommandHistory", visualWindowManager), Resumeable {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(CommandHistoryVisualWindow::class.java)
+    }
+
+    private val commandHistoryPanel by lazy { SystemInformationPanel() }
+    private val database get() = DatabaseManager.getInstance()
+
+    init {
+        Disposer.register(tab, this)
+        initViews()
+        initEvents()
+        initVisualWindowPanel()
+    }
+
+
+    private fun initViews() {
+        title = I18n.getString("termora.visual-window.command-history")
+        add(commandHistoryPanel, BorderLayout.CENTER)
+    }
+
+    private fun initEvents() {
+        Disposer.register(this, commandHistoryPanel)
+    }
+
+    private inner class SystemInformationPanel : AutoRefreshPanel() {
+
+        private val zshHistoryFile = File(SystemUtils.getUserHome(), ".zsh_history")
+        private val bashHistoryFile = File(SystemUtils.getUserHome(), ".bash_history")
+        private val model = DefaultListModel<String>()
+        private val filterTextField = FlatTextField()
+        private val historyList = object : JList<String>(model) {
+            override fun getScrollableTracksViewportWidth(): Boolean {
+                return true
+            }
+
+            override fun getToolTipText(event: MouseEvent): String? {
+                val index = locationToIndex(event.point)
+                if (index >= 0) {
+                    val bounds = getCellBounds(index, index)
+                    if (Objects.nonNull(bounds)) {
+                        if (bounds.contains(event.point)) {
+                            return model.getElementAt(index)
+                        }
+                    }
+                }
+                return super.getToolTipText(event)
+            }
+        }
+
+        init {
+            initViews()
+            initEvents()
+        }
+
+
+        private fun initViews() {
+            layout = BorderLayout()
+            add(createPanel(), BorderLayout.CENTER)
+
+            historyList.fixedCellHeight = UIManager.getInt("Tree.rowHeight")
+            historyList.selectionMode = ListSelectionModel.MULTIPLE_INTERVAL_SELECTION
+            historyList.background = DynamicColor("window")
+            historyList.cellRenderer = object : DefaultListCellRenderer() {
+                override fun getListCellRendererComponent(
+                    list: JList<*>?,
+                    value: Any?,
+                    index: Int,
+                    isSelected: Boolean,
+                    cellHasFocus: Boolean
+                ): Component {
+                    val text = value?.toString() ?: StringUtils.EMPTY
+                    return super.getListCellRendererComponent(
+                        list,
+                        text,
+                        index,
+                        isSelected,
+                        cellHasFocus
+                    )
+                }
+            }
+
+            filterTextField.background = historyList.background
+            filterTextField.leadingIcon = Icons.find
+            filterTextField.isShowClearButton = true
+        }
+
+        private fun createPanel(): JComponent {
+            val formMargin = "2dlu"
+            var rows = 1
+            val step = 2
+
+            val scrollPane = JScrollPane(historyList)
+            scrollPane.border = BorderFactory.createEmptyBorder()
+            scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER)
+            scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED)
+
+            return FormBuilder.create().debug(false)
+                .layout(FormLayout("default:grow", "fill:default:grow"))
+//                .add(filterTextField).xy(1, rows).apply { rows += step }
+                .add(scrollPane).xy(1, rows)
+                .padding("$formMargin, $formMargin, $formMargin, $formMargin")
+                .build()
+        }
+
+        private fun initEvents() {
+            historyList.addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    if (e.clickCount % 2 == 0) {
+                        val selectedIndex = historyList.selectedIndex
+                        if (selectedIndex < 0) return
+                        val text = model.getElementAt(selectedIndex)
+                        if (text.isBlank()) return
+                        val writer = tab.getData(DataProviders.TerminalWriter) ?: return
+                        writer.write(TerminalWriter.WriteRequest.fromBytes(text.toByteArray(writer.getCharset())))
+                        SwingUtilities.invokeLater { tab.getData(DataProviders.TerminalPanel)?.requestFocusInWindow() }
+                    }
+                }
+            })
+        }
+
+        override suspend fun refresh(isFirst: Boolean) {
+            val lines = mutableListOf<String>()
+
+            if (tab is LocalTerminalTab) {
+                val localShell = database.terminal.localShell
+                if (localShell.isBlank()) return
+                if (localShell.contains("zsh") && zshHistoryFile.exists()) {
+                    val text = String(ZshHistoryCodec.unmetafy(readHistoryFile(zshHistoryFile)))
+                    lines.addAll(ZshParser.parse(text.lines().iterator()))
+                } else if (bashHistoryFile.exists()) {
+                    val text = String(readHistoryFile(bashHistoryFile))
+                    lines.addAll(BashParser.parse(text.lines().iterator()))
+                }
+            } else if (tab is SSHTerminalTab) {
+                val session = tab.getData(SSHTerminalTab.SSHSession)
+                if (session != null) {
+                    val pair = SshClients.execChannel(session, "tail -n 100 ~/.bash_history")
+                    if (pair.first == 0) {
+                        lines.addAll(BashParser.parse(pair.second.lines().iterator()))
+                    }
+                }
+            }
+
+            if (lines.isEmpty()) return
+
+            if (model.isEmpty) {
+                withContext(Dispatchers.Swing) { model.addAll(lines) }
+                return
+            }
+
+            withContext(Dispatchers.Swing) {
+                val added = mutableListOf<String>()
+                while (lines.isNotEmpty()) {
+                    if (model.firstElement() != lines.first()) {
+                        added.add(lines.removeFirst())
+                    } else {
+                        break
+                    }
+                }
+
+                if (added.isNotEmpty()) {
+                    val selectedIndex = historyList.selectedIndex
+                    for ((i, element) in added.withIndex()) {
+                        model.insertElementAt(element, i)
+                    }
+                    if (selectedIndex >= 0) {
+                        historyList.selectedIndex = selectedIndex + added.size
+                    }
+                }
+            }
+        }
+
+        private fun readHistoryFile(file: File): ByteArray {
+            val process = Runtime.getRuntime().exec(arrayOf("tail", "-n", "100", file.absolutePath))
+            if (process.waitFor() == 0) {
+                return process.inputStream.use { it.readAllBytes() }
+            }
+            return byteArrayOf()
+        }
+
+
+    }
+
+    protected object Parser {
+        fun parse(iterator: Iterator<String>, lineCallback: (String) -> String): List<String> {
+            val lines = mutableListOf<String>()
+            val sb = StringBuilder()
+            while (iterator.hasNext()) {
+                var line = iterator.next()
+                if (line.isBlank()) continue
+                sb.clear().append(lineCallback.invoke(line))
+                if (line.endsWith('\\')) {
+                    while (line.endsWith('\\') && iterator.hasNext()) {
+                        line = iterator.next()
+                        sb.appendLine().append(line)
+                    }
+                }
+                lines.addLast(sb.toString())
+            }
+            return lines
+        }
+    }
+
+    protected object ZshParser {
+        fun parse(iterator: Iterator<String>): List<String> {
+            return Parser.parse(iterator) { it.split(";".toRegex(), 2).last() }.reversed()
+        }
+    }
+
+    protected object BashParser {
+        fun parse(iterator: Iterator<String>): List<String> {
+            return Parser.parse(iterator) { it }.reversed()
+        }
+    }
+
+    // https://www.zsh.org/mla/users/2011/msg00154.html
+    protected object ZshHistoryCodec {
+        private const val META = 0x83
+        private const val META_MASK = 0x20
+
+        fun unmetafy(input: ByteArray): ByteArray {
+            val out = ByteArray(input.size)
+            var i = 0
+            var j = 0
+
+            while (i < input.size) {
+                val b = input[i].toInt() and 0xFF
+                if (b == META) {
+                    if (i + 1 >= input.size) {
+                        out[j++] = input[i]
+                        i++
+                    } else {
+                        val next = input[i + 1].toInt() and 0xFF
+                        out[j++] = (next xor META_MASK).toByte()
+                        i += 2
+                    }
+                } else {
+                    out[j++] = input[i]
+                    i++
+                }
+            }
+
+            return out.copyOf(j)
+        }
+    }
+
+
+}

--- a/src/main/kotlin/app/termora/terminal/panel/vw/FloatingToolbarPlugin.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/vw/FloatingToolbarPlugin.kt
@@ -3,10 +3,7 @@ package app.termora.terminal.panel.vw
 import app.termora.plugin.Extension
 import app.termora.plugin.InternalPlugin
 import app.termora.terminal.panel.FloatingToolbarActionExtension
-import app.termora.terminal.panel.vw.extensions.NvidiaVisualWindowActionExtension
-import app.termora.terminal.panel.vw.extensions.ServerInfoVisualWindowActionExtension
-import app.termora.terminal.panel.vw.extensions.SnippetVisualWindowActionExtension
-import app.termora.terminal.panel.vw.extensions.TransferVisualWindowActionExtension
+import app.termora.terminal.panel.vw.extensions.*
 
 internal class FloatingToolbarPlugin : InternalPlugin() {
     init {
@@ -14,6 +11,7 @@ internal class FloatingToolbarPlugin : InternalPlugin() {
         support.addExtension(FloatingToolbarActionExtension::class.java) { ServerInfoVisualWindowActionExtension.instance }
         support.addExtension(FloatingToolbarActionExtension::class.java) { SnippetVisualWindowActionExtension.instance }
         support.addExtension(FloatingToolbarActionExtension::class.java) { NvidiaVisualWindowActionExtension.instance }
+        support.addExtension(FloatingToolbarActionExtension::class.java) { HistoryCommandVisualWindowActionExtension.instance }
     }
 
     override fun getName(): String {

--- a/src/main/kotlin/app/termora/terminal/panel/vw/extensions/HistoryCommandVisualWindowActionExtension.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/vw/extensions/HistoryCommandVisualWindowActionExtension.kt
@@ -1,0 +1,45 @@
+package app.termora.terminal.panel.vw.extensions
+
+import app.termora.I18n
+import app.termora.Icons
+import app.termora.TerminalTab
+import app.termora.actions.AnAction
+import app.termora.actions.AnActionEvent
+import app.termora.plugin.internal.local.LocalTerminalTab
+import app.termora.plugin.internal.ssh.SSHTerminalTab
+import app.termora.terminal.panel.FloatingToolbarActionExtension
+import app.termora.terminal.panel.vw.CommandHistoryVisualWindow
+import app.termora.terminal.panel.vw.VisualWindow
+import app.termora.terminal.panel.vw.VisualWindowManager
+import com.formdev.flatlaf.util.SystemInfo
+
+class HistoryCommandVisualWindowActionExtension private constructor() : FloatingToolbarActionExtension {
+
+    companion object {
+        val instance = HistoryCommandVisualWindowActionExtension()
+    }
+
+    override fun createActionButton(visualWindowManager: VisualWindowManager, tab: TerminalTab): AnAction {
+        if (tab is SSHTerminalTab || (tab is LocalTerminalTab && (SystemInfo.isLinux || SystemInfo.isMacOS))) {
+            return object : AnAction(Icons.history) {
+                init {
+                    putValue(SHORT_DESCRIPTION, I18n.getString("termora.visual-window.command-history"))
+                }
+
+                override fun actionPerformed(evt: AnActionEvent) {
+                    val visualWindowPanel = CommandHistoryVisualWindow(tab, visualWindowManager)
+                    visualWindowManager.addVisualWindow(visualWindowPanel)
+                }
+            }
+        }
+        throw UnsupportedOperationException()
+    }
+
+    override fun getVisualWindowClass(tab: TerminalTab): Class<out VisualWindow> {
+        throw UnsupportedOperationException()
+    }
+
+    override fun ordered(): Long {
+        return 4
+    }
+}

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -444,6 +444,8 @@ termora.visual-window.system-information.used-total=Used / Total
 termora.visual-window.toggle-window=Toggle window
 termora.visual-window.transport.question=More Features
 
+termora.visual-window.command-history=Command History
+
 
 termora.visual-window.nvidia-smi=NVIDIA SMI
 

--- a/src/main/resources/i18n/messages_pt_BR.properties
+++ b/src/main/resources/i18n/messages_pt_BR.properties
@@ -445,6 +445,8 @@ termora.visual-window.toggle-window=Alternar janela
 termora.visual-window.transport.question=Mais recursos
 
 
+termora.visual-window.command-history=Histórico de comandos
+
 termora.visual-window.nvidia-smi=NVIDIA SMI
 
 

--- a/src/main/resources/i18n/messages_ru_RU.properties
+++ b/src/main/resources/i18n/messages_ru_RU.properties
@@ -391,6 +391,8 @@ termora.visual-window.toggle-window=Переключить окно
 termora.visual-window.transport.question=Больше возможностей
 
 
+termora.visual-window.command-history=История командования
+
 termora.visual-window.nvidia-smi=NVIDIA SMI
 
 

--- a/src/main/resources/i18n/messages_zh_CN.properties
+++ b/src/main/resources/i18n/messages_zh_CN.properties
@@ -441,6 +441,8 @@ termora.visual-window.system-information.used-total=使用 / 大小
 termora.visual-window.toggle-window=切换窗口
 termora.visual-window.transport.question=更多功能
 
+termora.visual-window.command-history=命令历史
+
 termora.floating-toolbar.close-in-current-tab=在当前标签页关闭
 
 

--- a/src/main/resources/i18n/messages_zh_TW.properties
+++ b/src/main/resources/i18n/messages_zh_TW.properties
@@ -427,6 +427,8 @@ termora.visual-window.system-information.used-total=使用 / 大小
 termora.visual-window.toggle-window=切換視窗
 termora.visual-window.transport.question=更多功能
 
+termora.visual-window.command-history=命令歷史
+
 termora.floating-toolbar.close-in-current-tab=在目前標籤頁關閉
 
 # zmodem

--- a/src/main/resources/icons/history.svg
+++ b/src/main/resources/icons/history.svg
@@ -1,0 +1,5 @@
+<!-- Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="8" cy="8" r="6.5" stroke="#6C707E"/>
+<path d="M8 5V8L10.5 9.5" stroke="#6C707E" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/main/resources/icons/history_dark.svg
+++ b/src/main/resources/icons/history_dark.svg
@@ -1,0 +1,5 @@
+<!-- Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="8" cy="8" r="6.5" stroke="#CED0D6"/>
+<path d="M8 5V8L10.5 9.5" stroke="#CED0D6" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
#1236 #271 #350

<img width="750"  alt="image" src="https://github.com/user-attachments/assets/9ff49cae-e219-45da-b9c4-46ba80a222ad" />


对于本地终端仅支持 `Linux` 和 `macOS` 客户端，支持所有 SSH 服务器 (`bash`)

----

对于本地终端，会尝试读取 `~/.zsh_history`，其次 `~/.bash_history`。

对于 SSH 连接，只会读取 `~/.bash_history`