### PR TITLE
修复传输文件覆盖时的问题

### DIFF
--- a/src/main/kotlin/app/termora/transfer/DefaultInternalTransferManager.kt
+++ b/src/main/kotlin/app/termora/transfer/DefaultInternalTransferManager.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.withContext
 import org.apache.commons.lang3.StringUtils
 import org.apache.commons.lang3.time.DateFormatUtils
 import org.apache.sshd.sftp.client.fs.SftpPath
+import org.apache.sshd.sftp.client.fs.WithFileAttributes
 import org.slf4j.LoggerFactory
 import java.awt.Component
 import java.awt.Dimension
@@ -153,7 +154,7 @@ internal class DefaultInternalTransferManager(
         if (context.applyAll) return context.action
 
         if (path.exists()) {
-            val transfer = askTransfer(source, source)
+            val transfer = askTransfer(source, readAttributes(path))
             context.action = transfer.action
             context.applyAll = transfer.applyAll
             if (transfer.option != JOptionPane.OK_OPTION) return null
@@ -421,5 +422,37 @@ internal class DefaultInternalTransferManager(
         }
     }
 
+}
 
+internal fun readAttributes(path: Path): TransportTableModel.Attributes {
+    if (path is WithFileAttributes) {
+        val attrs = path.attributes
+        if (attrs != null) {
+            return TransportTableModel.Attributes(
+                name = path.name,
+                type = TransportTableModel.Attributes.computeType(attrs.isSymbolicLink, attrs.isDirectory, path.name),
+                isDirectory = attrs.isDirectory,
+                isFile = attrs.isRegularFile,
+                isSymbolicLink = attrs.isSymbolicLink,
+                fileSize = attrs.size,
+                permissions = fromSftpPermissions(attrs.permissions),
+                owner = attrs.owner ?: StringUtils.EMPTY,
+                lastModifiedTime = attrs.modifyTime.toMillis()
+            )
+        }
+    }
+    val basic = runCatching { Files.readAttributes(path, BasicFileAttributes::class.java) }.getOrNull()
+    val isDirectory = basic?.isDirectory ?: false
+    val isSymbolicLink = basic?.isSymbolicLink ?: false
+    return TransportTableModel.Attributes(
+        name = path.name,
+        type = TransportTableModel.Attributes.computeType(isSymbolicLink, isDirectory, path.name),
+        isDirectory = isDirectory,
+        isFile = basic?.isRegularFile ?: false,
+        isSymbolicLink = isSymbolicLink,
+        fileSize = basic?.size() ?: 0,
+        permissions = emptySet(),
+        owner = StringUtils.EMPTY,
+        lastModifiedTime = basic?.lastModifiedTime()?.toMillis() ?: 0
+    )
 }

--- a/src/test/kotlin/app/termora/transfer/DefaultInternalTransferManagerTest.kt
+++ b/src/test/kotlin/app/termora/transfer/DefaultInternalTransferManagerTest.kt
@@ -1,0 +1,55 @@
+package app.termora.transfer
+
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class DefaultInternalTransferManagerTest {
+
+    @Test
+    fun testReadAttributesReturnsOwnMtime() {
+        val targetFile = Files.createTempFile("termora-1488-target", ".txt")
+        try {
+            targetFile.writeText("target content")
+            val expectedMtime = 1_700_000_000_000L
+            Files.setLastModifiedTime(targetFile, FileTime.fromMillis(expectedMtime))
+
+            val attrs = readAttributes(targetFile)
+
+            assertEquals(expectedMtime, attrs.lastModifiedTime)
+            assertTrue(attrs.isFile)
+            assertFalse(attrs.isDirectory)
+        } finally {
+            targetFile.deleteIfExists()
+        }
+    }
+
+    // Regression for issue 1488: getTransferAction used to call askTransfer(source, source)
+    // for an already-existing target file, so the dialog displayed the source's mtime
+    // under the target column. The fix passes readAttributes(targetPath) instead, which
+    // must reflect the target's own mtime.
+    @Test
+    fun testReadAttributesDoesNotLeakSourceMtime() {
+        val sourceMtime = 1_700_000_000_000L
+        val targetMtime = 1_800_000_000_000L
+
+        val targetFile = Files.createTempFile("termora-1488-distinct", ".txt")
+        try {
+            targetFile.writeText("target")
+            Files.setLastModifiedTime(targetFile, FileTime.fromMillis(targetMtime))
+
+            val targetAttrs = readAttributes(targetFile)
+
+            assertEquals(targetMtime, targetAttrs.lastModifiedTime)
+            assertNotEquals(sourceMtime, targetAttrs.lastModifiedTime)
+        } finally {
+            targetFile.deleteIfExists()
+        }
+    }
+}


### PR DESCRIPTION
关于 #1488 的问题修复

修改之前：  
<img width="838" height="740" alt="14fa4d6e36a32ed073851c93d83a53fb" src="https://github.com/user-attachments/assets/0015dd13-acc9-4a2a-8e12-281db8c1d3b3" />

<img width="1302" height="382" alt="49a0ae600e1dd0f383a69de139e8752e" src="https://github.com/user-attachments/assets/f45d593e-fbfc-432a-b076-699097b922d0" />


原因是 source和target参数都填写了source 

修复之后： 
<img width="604" height="628" alt="26b97e0cb5915e417e25ac7ff1438c02" src="https://github.com/user-attachments/assets/2a0f9b47-4b67-4020-926a-d18f82982b0a" />
