### PR TITLE
Add German locale and README support

### DIFF
--- a/README.de_DE.md
+++ b/README.de_DE.md
@@ -1,0 +1,101 @@
+<div align="center">
+<a href="./README.md">English</a> | <a href="./README.zh_CN.md">简体中文</a> | <a href="./README.pt_BR.md">Português (Brasil)</a>
+</div>
+
+# Termora
+
+**Termora** ist ein plattformübergreifender Terminal-Emulator und SSH-Client für **Windows, macOS und Linux**.
+
+<div align="center">
+  <img src="docs/readme.png" alt="Readme" />
+</div>
+
+Termora wird mit [**Kotlin/JVM**](https://kotlinlang.org/) entwickelt und implementiert Teile des [**XTerm-Control-Sequence-Protokolls**](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html). Langfristig verfolgt das Projekt das Ziel, über [**Kotlin Multiplatform**](https://kotlinlang.org/docs/multiplatform.html) eine umfassende Plattformunterstützung zu ermöglichen — einschließlich Android, iOS und iPadOS.
+
+
+
+## ✨ Funktionen
+
+- 🧬 Plattformübergreifende Unterstützung
+- 🔐 Integrierte Schlüsselverwaltung
+- 🖼️ X11-Forwarding
+- 🧑‍💻 SSH-Agent-Integration
+- 💻 Anzeige von Systeminformationen
+- 📁 Grafische SFTP-Dateiverwaltung
+- 📊 Überwachung der Nvidia-GPU-Auslastung
+- ⚡ Schnellzugriff auf häufig genutzte Befehle
+
+
+## 🚀 Dateiübertragung
+
+- Direkte Übertragungen zwischen Server A ↔ B
+- Unterstützung für rekursive Ordnerübertragungen
+- Bis zu **6 parallele Übertragungsaufgaben**
+
+<div align="center">
+  <img src="docs/transfer.png" alt="Transfer" />
+</div>
+
+
+
+## 📝 Dateien bearbeiten
+
+- Automatischer Upload nach dem Bearbeiten und Speichern
+- Dateien und Ordner umbenennen
+- Große Ordner schnell löschen (`rm -rf` wird unterstützt)
+- Berechtigungen übersichtlich bearbeiten
+- Neue Dateien und Ordner erstellen
+
+<div align="center">
+  <img src="docs/transfer-edit.png" alt="Transfer Edit" />
+</div>
+
+## 💻 Hosts
+
+- Hierarchische Baumstruktur, ähnlich wie bei Ordnern
+- Tags für einzelne Hosts vergeben
+- Hosts aus anderen Tools importieren
+- Direkt mit dem Dateiübertragungs-Tool öffnen
+
+<div align="center">
+  <img src="docs/host.png" alt="Transfer Edit" />
+</div>
+
+## 🧩 Plugins
+
+- 🌍 Geo: Standortinformationen von Hosts anzeigen
+- 🔄 Sync: Einstellungen mit Gist oder WebDAV synchronisieren
+- 🗂️ WebDAV: Verbindung zu WebDAV-Speicher herstellen
+- 📝 Editor: Integrierter Editor für SFTP-Dateien
+- 📡 SMB: Verbindung zu [SMB](https://en.wikipedia.org/wiki/Server_Message_Block) herstellen
+- ☁️ S3: Verbindung zu S3-Objektspeicher herstellen
+- ☁️ Huawei OBS: Verbindung zu Huawei Cloud OBS herstellen
+- ☁️ Tencent COS: Verbindung zu Tencent Cloud COS herstellen
+- ☁️ Alibaba OSS: Verbindung zu Alibaba Cloud OSS herstellen
+- 👉 [Alle Plugins ansehen...](https://www.termora.app/plugins)
+
+
+
+
+## 📦 Download
+
+- 🧾 [Neueste Version](https://github.com/TermoraDev/termora/releases/latest)
+- 🍺 **Homebrew**: `brew install --cask termora`
+- 🔨 **WinGet**: `winget install termora`
+- <img src="https://apps.microsoft.com/assets/icons/logo-16x16.png" alt="microsoft logo"/> <b>Microsoft Store</b>: <a href="https://apps.microsoft.com/store/detail/9NRZBHG43SB9?cid=DevShareMCLPCS">Termora im Microsoft Store ansehen</a>
+
+
+
+## 🛠️ Entwicklung
+
+Für die Entwicklung empfehlen wir das [JetBrainsRuntime](https://github.com/JetBrains/JetBrainsRuntime) JDK.
+
+- Lokal starten: `./gradlew :run`
+
+
+## 📄 Lizenz
+
+Diese Software wird unter einem Dual-License-Modell veröffentlicht. Du kannst eine der folgenden Optionen wählen:
+
+- **AGPL-3.0**: Die Software darf gemäß den Bedingungen der [AGPL-3.0](https://opensource.org/license/agpl-v3) genutzt, verteilt und verändert werden.
+- **Proprietäre Lizenz**: Für Closed-Source- oder proprietäre Nutzung kontaktiere bitte den Autor, um eine kommerzielle Lizenz zu erhalten.

--- a/README.de_DE.md
+++ b/README.de_DE.md
@@ -10,7 +10,7 @@
   <img src="docs/readme.png" alt="Readme" />
 </div>
 
-Termora wird mit [**Kotlin/JVM**](https://kotlinlang.org/) entwickelt und implementiert Teile des [**XTerm-Control-Sequence-Protokolls**](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html). Langfristig verfolgt das Projekt das Ziel, über [**Kotlin Multiplatform**](https://kotlinlang.org/docs/multiplatform.html) eine umfassende Plattformunterstützung zu ermöglichen — einschließlich Android, iOS und iPadOS.
+Termora wird mit [**Kotlin/JVM**](https://kotlinlang.org/) entwickelt und implementiert Teile des [**XTerm-Steuersequenzprotokolls**](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html). Langfristig verfolgt das Projekt das Ziel, mit [**Kotlin Multiplatform**](https://kotlinlang.org/docs/multiplatform.html) eine umfassende Plattformunterstützung zu erreichen, einschließlich Android, iOS und iPadOS.
 
 
 
@@ -55,7 +55,7 @@ Termora wird mit [**Kotlin/JVM**](https://kotlinlang.org/) entwickelt und implem
 - Hierarchische Baumstruktur, ähnlich wie bei Ordnern
 - Tags für einzelne Hosts vergeben
 - Hosts aus anderen Tools importieren
-- Direkt mit dem Dateiübertragungs-Tool öffnen
+- Direkt im Dateiübertragungs-Tool öffnen
 
 <div align="center">
   <img src="docs/host.png" alt="Transfer Edit" />
@@ -63,15 +63,15 @@ Termora wird mit [**Kotlin/JVM**](https://kotlinlang.org/) entwickelt und implem
 
 ## 🧩 Plugins
 
-- 🌍 Geo: Standortinformationen von Hosts anzeigen
+- 🌍 Geo: Geolokalisierung von Hosts anzeigen
 - 🔄 Sync: Einstellungen mit Gist oder WebDAV synchronisieren
-- 🗂️ WebDAV: Verbindung zu WebDAV-Speicher herstellen
-- 📝 Editor: Integrierter Editor für SFTP-Dateien
-- 📡 SMB: Verbindung zu [SMB](https://en.wikipedia.org/wiki/Server_Message_Block) herstellen
-- ☁️ S3: Verbindung zu S3-Objektspeicher herstellen
-- ☁️ Huawei OBS: Verbindung zu Huawei Cloud OBS herstellen
-- ☁️ Tencent COS: Verbindung zu Tencent Cloud COS herstellen
-- ☁️ Alibaba OSS: Verbindung zu Alibaba Cloud OSS herstellen
+- 🗂️ WebDAV: Verbindung mit WebDAV-Speicher herstellen
+- 📝 Editor: Integrierter SFTP-Dateieditor
+- 📡 SMB: Verbindung mit [SMB](https://en.wikipedia.org/wiki/Server_Message_Block) herstellen
+- ☁️ S3: Verbindung mit S3-Objektspeicher herstellen
+- ☁️ Huawei OBS: Verbindung mit Huawei Cloud OBS herstellen
+- ☁️ Tencent COS: Verbindung mit Tencent Cloud COS herstellen
+- ☁️ Alibaba OSS: Verbindung mit Alibaba Cloud OSS herstellen
 - 👉 [Alle Plugins ansehen...](https://www.termora.app/plugins)
 
 
@@ -88,14 +88,14 @@ Termora wird mit [**Kotlin/JVM**](https://kotlinlang.org/) entwickelt und implem
 
 ## 🛠️ Entwicklung
 
-Für die Entwicklung empfehlen wir das [JetBrainsRuntime](https://github.com/JetBrains/JetBrainsRuntime) JDK.
+Für die Entwicklung empfehlen wir das [JetBrainsRuntime](https://github.com/JetBrains/JetBrainsRuntime)-JDK.
 
 - Lokal starten: `./gradlew :run`
 
 
 ## 📄 Lizenz
 
-Diese Software wird unter einem Dual-License-Modell veröffentlicht. Du kannst eine der folgenden Optionen wählen:
+Diese Software wird unter einem Dual-License-Modell veröffentlicht. Du kannst zwischen den folgenden Optionen wählen:
 
 - **AGPL-3.0**: Die Software darf gemäß den Bedingungen der [AGPL-3.0](https://opensource.org/license/agpl-v3) genutzt, verteilt und verändert werden.
 - **Proprietäre Lizenz**: Für Closed-Source- oder proprietäre Nutzung kontaktiere bitte den Autor, um eine kommerzielle Lizenz zu erhalten.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<a href="./README.zh_CN.md">简体中文</a> | <a href="./README.pt_BR.md">Português (Brasil)</a>
+<a href="./README.de_DE.md">Deutsch</a> | <a href="./README.zh_CN.md">简体中文</a> | <a href="./README.pt_BR.md">Português (Brasil)</a>
 </div>
 
 # Termora

--- a/README.pt_BR.md
+++ b/README.pt_BR.md
@@ -1,5 +1,5 @@
 <div align="center">
-<a href="./README.md">English</a> | <a href="./README.zh_CN.md">简体中文</a>
+<a href="./README.md">English</a> | <a href="./README.de_DE.md">Deutsch</a> | <a href="./README.zh_CN.md">简体中文</a>
 </div>
 
 # Termora

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -1,3 +1,7 @@
+<div align="center">
+<a href="./README.md">English</a> | <a href="./README.de_DE.md">Deutsch</a> | <a href="./README.pt_BR.md">Português (Brasil)</a>
+</div>
+
 # Termora
 
 **Termora** 是一款跨平台终端模拟器和 SSH 客户端，支持 **Windows、macOS、Linux**。

--- a/src/main/kotlin/app/termora/I18n.kt
+++ b/src/main/kotlin/app/termora/I18n.kt
@@ -22,6 +22,7 @@ object I18n : AbstractI18n() {
         "zh_TW" to "繁體中文",
         "ru_RU" to "Русский",
         "pt_BR" to "Português",
+        "de_DE" to "Deutsch",
     )
 
     fun containsLanguage(locale: Locale): String? {

--- a/src/main/resources/i18n/messages_de_DE.properties
+++ b/src/main/resources/i18n/messages_de_DE.properties
@@ -1,0 +1,505 @@
+termora.title=Termora
+termora.confirm=Bestätigen
+termora.exit=退出
+termora.cancel=Abbrechen
+termora.copy=Kopieren
+termora.paste=Paste
+termora.apply=Übernehmen
+termora.save=Speichern
+termora.remove=Löschen
+termora.yes=Ja
+termora.no=Nein
+termora.date-format=dd.MM.yyyy HH:mm:ss
+termora.finder=Finder
+termora.folder=Ordner
+termora.file=File
+termora.explorer=Dateimanager
+termora.quit-confirm=Möchtest du {0} wirklich beenden?
+
+termora.regex=Regex
+termora.match-case=Match Case
+termora.optional=Optional
+
+# update
+termora.update.title=Neue Version verfügbar
+termora.update.update=Aktualisieren
+
+# Hosts
+termora.host.modified-server-key.title=Die Identität des Hosts [{0}] hat sich geändert
+termora.host.modified-server-key.thumbprint=Fingerabdruck des Host-Schlüssels
+termora.host.modified-server-key.expected=Erwartet
+termora.host.modified-server-key.actual=Erhalten
+termora.host.modified-server-key.are-you-sure=Möchtest du die Verbindung trotzdem fortsetzen?
+
+
+# Settings
+termora.setting=Einstellungen
+
+termora.settings.appearance=Darstellung
+termora.settings.appearance.theme=Design
+termora.settings.appearance.layout=Layout
+termora.settings.appearance.layout.screen=Screen
+termora.settings.appearance.layout.fence=Split
+termora.settings.appearance.language=Sprache
+termora.settings.appearance.i-want-to-translate=Ich möchte beim Übersetzen helfen
+termora.settings.appearance.follow-system=Systemeinstellung verwenden
+termora.settings.appearance.opacity=Deckkraft
+termora.settings.appearance.background-running=Im Hintergrund weiterlaufen
+termora.settings.appearance.tab-order=Tab Order
+termora.settings.appearance.confirm-tab-close=Vor dem Schließen von Tabs nachfragen
+
+termora.settings.terminal=Terminal
+termora.settings.terminal.font=Schriftart
+termora.settings.terminal.fallback-font=Fallback Font
+termora.settings.terminal.size=Schriftgröße
+termora.settings.terminal.max-rows=Maximale Zeilen
+termora.settings.terminal.debug=Debug-Modus
+termora.settings.terminal.beep=Signalton
+termora.settings.terminal.hyperlink=Links erkennen
+termora.settings.terminal.select-copy=Beim Markieren kopieren
+termora.settings.terminal.right-click=Right click
+termora.settings.terminal.right-click.copy-and-paste=Copy and Paste
+termora.settings.terminal.right-click.nothing=Nothing
+termora.settings.terminal.right-click.copy=${termora.copy}
+termora.settings.terminal.cursor-style=Cursor-Stil
+termora.settings.terminal.cursor-blink=Cursor blinken lassen
+termora.settings.terminal.local-shell=Lokale Shell
+termora.settings.terminal.floating-toolbar=Schwebende Werkzeugleiste
+termora.settings.terminal.auto-close-tab=Tab automatisch schließen
+termora.settings.terminal.auto-close-tab-description=Schließt den Tab automatisch, wenn die Terminalverbindung regulär beendet wurde
+
+
+termora.settings.about=Über Termora
+termora.settings.about.author=Autor
+termora.settings.about.source=Quellcode
+termora.settings.about.issue=Problem melden
+termora.settings.about.third-party=Drittanbieter-Abhängigkeiten
+termora.settings.about.termora=<html><b>${termora.title}</b> ({0}) ist ein plattformübergreifender SSH-Client.</html>
+
+termora.settings.plugin=Plugins
+termora.settings.plugin.install=Install
+termora.settings.plugin.installed=Installed
+termora.settings.plugin.marketplace=Marketplace
+termora.settings.plugin.uninstall=Uninstall
+termora.settings.plugin.uninstall-confirm=Are you sure you want to uninstall <b>{0}</b> ?
+termora.settings.plugin.uninstall-failed=Uninstall failed
+termora.settings.plugin.install-failed=Install failed, please try again later
+termora.settings.plugin.install-from-disk=Install Plugin from Disk...
+termora.settings.plugin.manage-plugin-repository=Manage Plugin Repository...
+termora.settings.plugin.install-from-disk-warning=<b>{0}</b> plugin will have access to all your data. Are you sure you want to install it?
+termora.settings.plugin.not-compatible=The plugin <b>{0}</b> is incompatible with the current version. Please reinstall <b>{0}</b>
+
+termora.settings.account=Account
+termora.settings.account.login=Log in
+termora.settings.account.server=Server
+termora.settings.account.wait-login=Waiting for login in the default browser...
+termora.settings.account.locally=locally
+termora.settings.account.lifetime=Lifetime
+termora.settings.account.upgrade=Upgrade
+termora.settings.account.verify=Verify
+termora.settings.account.subscription=Subscription
+termora.settings.account.valid-to=Valid to
+termora.settings.account.synchronization-on=Synchronization on
+termora.settings.account.sync-now=Sync now
+termora.settings.account.logout=Log out
+termora.settings.account.logout-confirm=Are you sure you want to log out?
+termora.settings.account.unsynced-logout-confirm=Unsynced Are you sure you want to log out?
+termora.settings.account.server-singapore=Singapore
+termora.settings.account.server-china=Mainland China
+termora.settings.account.new-server=New Server
+termora.settings.account.deploy-server=Deploy
+termora.settings.account.login-failed=Log in failed, please try again later
+
+
+termora.settings.keymap=Tastatur
+termora.settings.keymap.shortcut=Tastenkürzel
+termora.settings.keymap.action=Aktion
+termora.settings.keymap.already-exists=Das Tastenkürzel [{0}] wird bereits von [{1}] verwendet
+termora.settings.keymap.question=Select a line, press the <font color=rgb({0},{1},{2})> ⌫ (Backspace)</font> key to remove the shortcut
+
+termora.settings.sftp.edit-command=Bearbeitungsbefehl
+termora.settings.sftp.db-click-behavior=Double-click
+termora.settings.sftp.fixed-tab=Tab anheften
+termora.settings.sftp.default-directory=Standardverzeichnis
+termora.settings.sftp.preserve-time=Änderungszeit beibehalten
+
+
+termora.settings.restart.title=Neustart erforderlich
+termora.settings.restart.message=Die Änderungen werden nach einem Neustart wirksam
+termora.settings.restart.manually=Please restart the software manually
+
+# Find everywhere
+termora.find-everywhere=Suchen
+termora.find-everywhere.search-for-something=Wonach suchst du?
+termora.find-everywhere.groups.quick-actions=Schnellaktionen
+termora.find-everywhere.groups.open-new-hosts=Neue Verbindungen öffnen
+termora.find-everywhere.groups.opened-hosts=Geöffnete Verbindungen
+termora.find-everywhere.groups.tools=Werkzeuge
+termora.find-everywhere.groups.settings=${termora.setting}
+termora.find-everywhere.quick-command.local-terminal=Lokales Terminal
+
+# Welcome
+termora.welcome.my-hosts=Meine Verbindungen
+termora.welcome.toggle-sidebar=Toggle Sidebar
+termora.welcome.contextmenu.connect=Verbinden
+termora.welcome.contextmenu.connect-with=Verbinden mit
+termora.welcome.contextmenu.open-in-new-window=${termora.tabbed.contextmenu.open-in-new-window}
+termora.welcome.contextmenu.refresh=${termora.transport.table.contextmenu.refresh}
+termora.welcome.contextmenu.copy=${termora.copy}
+termora.welcome.contextmenu.remove=${termora.remove}
+termora.welcome.contextmenu.rename=Umbenennen
+termora.welcome.contextmenu.expand-all=Alle ausklappen
+termora.welcome.contextmenu.collapse-all=Alle einklappen
+termora.welcome.contextmenu.new=Neu
+termora.welcome.contextmenu.import=${termora.keymgr.import}
+termora.welcome.contextmenu.new.folder=Ordner
+termora.welcome.contextmenu.new.host=Verbindung
+termora.welcome.contextmenu.new.folder.name=Neuer Ordner
+termora.welcome.contextmenu.property=Eigenschaften
+termora.welcome.contextmenu.show=Show
+termora.welcome.contextmenu.show.more-info=More info
+termora.welcome.contextmenu.show.tags=${termora.tag}
+termora.welcome.contextmenu.download=Herunterladen
+termora.welcome.contextmenu.import.csv.download-template=Möchtest du Daten importieren oder die Vorlage herunterladen?
+termora.welcome.contextmenu.import.csv.download-template-done=Download abgeschlossen
+termora.welcome.contextmenu.import.csv.download-template-done-open-folder=Download abgeschlossen. Möchtest du den Zielordner öffnen?
+termora.welcome.contextmenu.import.xshell-folder-empty=In diesem Ordner wurden keine *.xsh-Dateien gefunden. Bitte wähle das richtige Xshell-Sitzungsverzeichnis aus
+termora.welcome.contextmenu.import.finalshell-folder-empty=In diesem Ordner wurden keine *_connect_config.json-Dateien gefunden. Bitte wähle das richtige FinalShell-Konfigurationsverzeichnis aus
+
+# New Host
+termora.new-host.title=Neue Verbindung erstellen
+termora.new-host.general=Allgemein
+termora.new-host.general.name=Name
+termora.new-host.general.protocol=Protokoll
+termora.new-host.general.host=Host
+termora.new-host.general.port=Port
+termora.new-host.general.username=Benutzername
+termora.new-host.general.authentication=Authentifizierung
+termora.new-host.general.password=Passwort
+termora.new-host.general.remark=Notiz
+termora.new-host.general.remember=Speichern
+
+termora.new-host.proxy=Proxy
+
+termora.new-host.terminal=${termora.settings.terminal}
+termora.new-host.terminal.encoding=Zeichencodierung
+termora.new-host.terminal.backspace=Backspace
+termora.new-host.terminal.character-mode=Character-at-a-time
+termora.new-host.terminal.heartbeat-interval=Keepalive-Intervall
+termora.new-host.terminal.timeout=Timeout
+termora.new-host.terminal.startup-commands=Startbefehle
+termora.new-host.terminal.alt-modifier=Alt modifier
+termora.new-host.terminal.alt-modifier.eight-bit=8-bit characters
+termora.new-host.terminal.alt-modifier.by-esc=Characters preceded by ESC
+termora.new-host.terminal.env=Umgebungsvariablen
+termora.new-host.terminal.login-scripts=Login Scripts
+termora.new-host.terminal.expect=Expect
+termora.new-host.terminal.send=Send
+
+termora.new-host.serial=Serielle Verbindung
+termora.new-host.serial.port=Port
+termora.new-host.serial.baud-rate=Baudrate
+termora.new-host.serial.data-bits=Datenbits
+termora.new-host.serial.parity=Parität
+termora.new-host.serial.stop-bits=Stoppbits
+termora.new-host.serial.flow-control=Flusskontrolle
+
+termora.new-host.tunneling=Tunnel
+termora.new-host.tunneling.table.name=Name
+termora.new-host.tunneling.table.type=Typ
+termora.new-host.tunneling.table.source=Lokale Adresse
+termora.new-host.tunneling.table.destination=Zieladresse
+termora.new-host.tunneling.add=Hinzufügen
+termora.new-host.tunneling.edit=${termora.keymgr.edit}
+termora.new-host.tunneling.delete=${termora.remove}
+
+termora.new-host.rdp.desktop-placeholder=Default full screen (e.g. 1920×1080)
+termora.new-host.rdp.resolution=Resolution
+
+
+termora.new-host.wsl.distribution=DistroName
+
+termora.new-host.test-connection=Verbindung testen
+termora.new-host.test-connection-successful=Verbindung erfolgreich
+
+
+termora.new-host.jump-hosts=Jump-Hosts
+
+# Key manager
+termora.keymgr.title=Schlüsselverwaltung
+termora.keymgr.my-keys=My keys
+termora.keymgr.generate=Erstellen
+termora.keymgr.import=Importieren
+termora.keymgr.export=Exportieren
+termora.keymgr.edit=Bearbeiten
+termora.keymgr.private-key=Private Key
+termora.keymgr.delete-warning=Möchtest du diesen Schlüssel wirklich löschen?
+termora.keymgr.table.name=Name
+termora.keymgr.table.type=Typ
+termora.keymgr.table.length=Länge
+termora.keymgr.table.remark=Notiz
+termora.keymgr.export-done=The export was successful
+termora.keymgr.export-done-open-folder=The export was successful. Do you want to open the folder?
+
+termora.keymgr.ssh-copy-id.number=Hosts: [{0}]    Öffentliche Schlüssel: [{1}]
+termora.keymgr.ssh-copy-id.successful=${termora.terminal.copied}
+termora.keymgr.ssh-copy-id.failed=Kopieren fehlgeschlagen
+termora.keymgr.ssh-copy-id.end=Öffentlicher Schlüssel wurde kopiert
+
+
+# Tabbed
+termora.tabbed.contextmenu.rename=Umbenennen
+termora.tabbed.contextmenu.select-host=Select Host
+termora.tabbed.contextmenu.sftp-command=SFTP-Terminal
+termora.tabbed.contextmenu.sftp-not-install=SFTP wurde nicht gefunden. Bitte installiere SFTP und versuche es erneut
+termora.tabbed.contextmenu.clone=Duplizieren
+termora.tabbed.contextmenu.clone-session=Clone Session
+termora.tabbed.contextmenu.open-in-new-window=In neuem Fenster öffnen
+termora.tabbed.contextmenu.close=Schließen
+termora.tabbed.contextmenu.close-other-tabs=Andere Tabs schließen
+termora.tabbed.contextmenu.close-all-tabs=Alle Tabs schließen
+termora.tabbed.contextmenu.reconnect=Neu verbinden
+termora.tabbed.local-tab.close-prompt=Möchtest du den laufenden Prozess in diesem Terminal beenden?
+termora.tabbed.tab.close-prompt=Möchtest du diesen Tab wirklich schließen?
+
+# Terminal logger
+termora.terminal-logger=Terminal-Protokoll
+termora.terminal-logger.start-recording=Aufzeichnung starten
+termora.terminal-logger.plain-text=Plain text
+termora.terminal-logger.styled-text=Styled text
+termora.terminal-logger.stop-recording=Aufzeichnung stoppen
+termora.terminal-logger.open-log-viewer=Protokoll anzeigen
+termora.terminal-logger.open-in-folder=In {0} öffnen
+
+
+# Highlight
+termora.highlight=Schlüsselwort-Hervorhebung
+termora.highlight.default-set=Default Set
+termora.highlight.text-color=Textfarbe
+termora.highlight.background-color=Hintergrundfarbe
+termora.highlight.keyword=Schlüsselwort
+termora.highlight.my-keyword=My Keyword
+termora.highlight.preview=Vorschau
+termora.highlight.description=Notiz
+termora.highlight.bold=Fett
+termora.highlight.italic=Kursiv
+termora.highlight.underline=Unterstrichen
+termora.highlight.line-through=Durchgestrichen
+
+# tag
+termora.tag=Tags
+termora.tag.my-tags=My tags
+termora.tag.manage-tags=Manage tags
+
+# Macro
+termora.macro=Makro
+termora.macro.start-recording=Aufzeichnung starten
+termora.macro.stop-recording=Aufzeichnung stoppen
+termora.macro.playback=Wiedergeben
+termora.macro.manager=Makros verwalten
+termora.macro.run=Ausführen
+
+# Snippets
+termora.snippet=Snippet
+termora.snippet.title=Code-Snippet
+
+# Tools
+termora.tools.multiple=Befehl an alle Sitzungen im aktuellen Fenster senden
+
+# Transport
+termora.transport.local=Lokal
+termora.transport.file-already-exists=Die Datei {0} existiert bereits
+
+
+termora.transport.toolbar.prev=Backward
+termora.transport.toolbar.home=Home Folder
+termora.transport.toolbar.next=Forward
+termora.transport.toolbar.parent=Parent Folder
+termora.transport.toolbar.show-hide=Show/Hide Folders
+termora.transport.toolbar.refresh=Refresh Folder
+
+termora.transport.bookmarks=Lesezeichen verwalten
+termora.transport.bookmarks.up=Nach oben
+termora.transport.bookmarks.down=Nach unten
+
+termora.transport.table.filename=Dateiname
+termora.transport.table.type=Typ
+termora.transport.table.type.symbolic-link=Symbolischer Link
+termora.transport.table.size=Größe
+termora.transport.table.modified-time=Geändert am
+termora.transport.table.permissions=Berechtigungen
+termora.transport.table.owner=Besitzer
+
+# contextmenu
+termora.transport.table.contextmenu.transfer=Übertragen
+termora.transport.table.contextmenu.edit=${termora.keymgr.edit}
+termora.transport.table.contextmenu.copy-path=Pfad kopieren
+termora.transport.table.contextmenu.open-in-folder=In {0} öffnen
+termora.transport.table.contextmenu.rename=${termora.welcome.contextmenu.rename}
+termora.transport.table.contextmenu.delete=${termora.remove}
+termora.transport.table.contextmenu.rm-warning=Das Löschen mit rm -rf ist riskant und kann nicht einfach rückgängig gemacht werden
+termora.transport.table.contextmenu.change-permissions=Berechtigungen ändern...
+termora.transport.table.contextmenu.refresh=Aktualisieren
+termora.transport.table.contextmenu.compress=Compress
+termora.transport.table.contextmenu.extract=Extract
+termora.transport.table.contextmenu.extract.here=Extract here
+termora.transport.table.contextmenu.extract.single=Extract to {0}\\
+termora.transport.table.contextmenu.extract.multi=Extract to *\\*
+termora.transport.table.contextmenu.new=${termora.welcome.contextmenu.new}
+termora.transport.table.contextmenu.new.folder=${termora.welcome.contextmenu.new.folder.name}
+termora.transport.table.contextmenu.new.file=${termora.transport.table.contextmenu.new}Datei
+
+# Permission
+termora.transport.permissions=Berechtigungen ändern
+termora.transport.permissions.file-folder-permissions=Datei- und Ordnerberechtigungen
+termora.transport.permissions.octal-mode=Octal mode
+termora.transport.permissions.read=Lesen
+termora.transport.permissions.write=Schreiben
+termora.transport.permissions.execute=Ausführen
+termora.transport.permissions.owner=Besitzer
+termora.transport.permissions.group=Gruppe
+termora.transport.permissions.others=Andere
+termora.transport.permissions.include-subfolder=Unterordner einbeziehen
+
+termora.transport.sftp=Transfer
+termora.transport.sftp.retry=Erneut versuchen
+termora.transport.sftp.select-another-host=Anderen Host auswählen
+termora.transport.sftp.select-host=Host auswählen
+termora.transport.sftp.connecting=Verbindung wird hergestellt...
+termora.transport.sftp.closed=Die Verbindung wurde geschlossen
+termora.transport.sftp.close-tab=Es laufen noch Übertragungen. Möchtest du alle Übertragungen abbrechen und diese Sitzung schließen?
+termora.transport.sftp.close-tab-has-active-session=Diese Sitzung ist noch aktiv. Möchtest du alle Sitzungen schließen?
+termora.transport.sftp.status.transporting=Wird übertragen
+termora.transport.sftp.status.deleting=Deleting
+termora.transport.sftp.status.waiting=Wartet
+termora.transport.sftp.status.done=Abgeschlossen
+termora.transport.sftp.status.failed=Fehlgeschlagen
+
+termora.transport.sftp.already-exists.message1=In diesem Ordner gibt es bereits Objekte mit diesen Namen
+termora.transport.sftp.already-exists.message2=Wähle aus, was passieren soll
+termora.transport.sftp.already-exists.overwrite=Überschreiben
+termora.transport.sftp.already-exists.append=Anhängen
+termora.transport.sftp.already-exists.skip=Überspringen
+termora.transport.sftp.already-exists.apply-all=Für alle übernehmen
+termora.transport.sftp.already-exists.name=Name
+termora.transport.sftp.already-exists.destination=Zieldatei
+termora.transport.sftp.already-exists.source=Quelldatei
+termora.transport.sftp.already-exists.actions=Aktionen
+
+
+# transport job
+termora.transport.jobs.table.name=Name
+termora.transport.jobs.table.status=Status
+termora.transport.jobs.table.progress=Fortschritt
+termora.transport.jobs.table.size=Größe
+termora.transport.jobs.table.source-path=Quellpfad
+termora.transport.jobs.table.target-path=Zielpfad
+termora.transport.jobs.table.speed=Geschwindigkeit
+termora.transport.jobs.table.estimated-time=Verbleibende Zeit
+termora.transport.jobs.table.estimated-time-days-format={0} Tage {1} Stunden {2} Minuten {3} Sekunden
+termora.transport.jobs.table.estimated-time-hours-format={0} Stunden {1} Minuten {2} Sekunden
+termora.transport.jobs.table.estimated-time-minutes-format={0} Minuten {1} Sekunden
+termora.transport.jobs.table.estimated-time-seconds-format={0} Sekunden
+
+termora.transport.jobs.contextmenu.delete=${termora.remove}
+termora.transport.jobs.contextmenu.delete-all=Alle löschen
+
+# ToolBar
+termora.toolbar.customize-toolbar=Werkzeugleiste anpassen...
+
+
+# Actions
+termora.actions.copy-from-terminal=Aus Terminal kopieren
+termora.actions.focus-mode=Focus Mode
+termora.actions.paste-to-terminal=In Terminal einfügen
+termora.actions.select-all-in-terminal=Alles im Terminal auswählen
+termora.actions.open-terminal-find=Im Terminal suchen
+termora.actions.close-tab=Tab schließen
+termora.actions.zoom-in-terminal=Terminal vergrößern
+termora.actions.zoom-out-terminal=Terminal verkleinern
+termora.actions.zoom-reset-terminal=Terminal-Zoom zurücksetzen
+termora.actions.open-local-terminal=Lokales Terminal öffnen
+termora.actions.quick-connect=Quick Connect
+termora.actions.open-find-everywhere=Globale Suche öffnen
+termora.actions.open-new-window=Neues Fenster öffnen
+termora.actions.clear-screen=Terminal leeren
+termora.actions.open-sftp-command=SFTP-Terminal öffnen
+termora.actions.switch-tab=Zu Tab [1..9] wechseln
+
+# Terminal
+termora.terminal.size=Größe: {0} x {1}
+termora.terminal.copied=Kopiert
+termora.terminal.channel-disconnected=Terminalverbindung getrennt.
+termora.terminal.channel-reconnect=Drücke {0}, um die Verbindung erneut herzustellen.
+
+# protocol
+termora.protocol.not-supported={0} protocol is not supported, you may need to install the plugin
+
+# Visual Window
+termora.visual-window.system-information=Systeminformationen
+termora.visual-window.system-information.mem=Arbeitsspeicher
+termora.visual-window.system-information.swap=Swap
+termora.visual-window.system-information.filesystem=Dateisystem
+termora.visual-window.system-information.used-total=Belegt / Gesamt
+termora.visual-window.toggle-window=Toggle window
+termora.visual-window.transport.question=More Features
+
+termora.visual-window.command-history=Command History
+
+
+termora.visual-window.nvidia-smi=NVIDIA SMI
+
+
+termora.floating-toolbar.close-in-current-tab=Im aktuellen Tab schließen
+
+
+# zmodem
+termora.addons.zmodem.skip=Überspringen
+
+
+
+
+# Additional German keys kept from the custom translation file
+termora.update.ignore=Später erinnern
+termora.doorman.safe=Deine Daten sind verschlüsselt
+termora.doorman.unlock-data=Passwort eingeben, um deine Daten zu entsperren
+termora.doorman.password-wrong=Das Passwort ist falsch
+termora.doorman.password-correct=Passwort bestätigt
+termora.doorman.verify-password=Passwort zur Bestätigung eingeben
+termora.doorman.unsafe=Deine Daten werden unverschlüsselt gespeichert
+termora.doorman.lock-data=Lege ein Passwort fest. Danach wird es bei jedem Start benötigt
+termora.doorman.forget-password=Passwort vergessen?
+termora.doorman.delete-data=Lösche das Datenverzeichnis und starte die Anwendung neu. Dabei gehen alle Daten verloren
+termora.doorman.forget-password-message=Du kannst deine Daten mit der Wiederherstellungsphrase entsperren. Ohne diese Phrase ist eine Wiederherstellung nicht möglich
+termora.doorman.have-a-mnemonic=Ich habe eine Wiederherstellungsphrase
+termora.doorman.dont-have-a-mnemonic=Ich habe keine Wiederherstellungsphrase
+termora.doorman.mnemonic-data-corrupted=Die Daten konnten mit der Wiederherstellungsphrase nicht entschlüsselt werden. Sie sind möglicherweise beschädigt
+termora.doorman.mnemonic.title=12 Wiederherstellungswörter eingeben
+termora.doorman.mnemonic.incorrect=Die Wiederherstellungsphrase ist ungültig
+termora.settings.appearance.background-image=Hintergrundbild
+termora.setting.security=Sicherheit
+termora.setting.security.enter-password=Passwort eingeben
+termora.setting.security.enter-password-again=Passwort erneut eingeben
+termora.setting.security.password-is-different=Die Passwörter stimmen nicht überein
+termora.setting.security.mnemonic-note=Bewahre deine Wiederherstellungsphrase sicher auf. Du benötigst sie, falls du dein Passwort vergisst
+termora.settings.sync=Synchronisierung
+termora.settings.sync.export-done=Export abgeschlossen
+termora.settings.sync.export-encrypt=Passwort zum Verschlüsseln der Datei eingeben (optional)
+termora.settings.sync.export-done-open-folder=Export abgeschlossen. Möchtest du den Zielordner öffnen?
+termora.settings.sync.range=Umfang
+termora.settings.sync.range.keys=Meine Schlüssel
+termora.settings.sync.last-sync-time=Letzte Synchronisierung
+termora.settings.sync.done=Daten erfolgreich synchronisiert
+termora.settings.sync.import.file-too-large=Die Datei ist zu groß
+termora.settings.sync.import.successful=Import abgeschlossen
+termora.settings.sync.gist=Gist
+termora.settings.sync.token=Token
+termora.settings.sync.type=Typ
+termora.settings.sync.webdav.help=WebDAV-Speicherort, z. B.: https://yourhost/webdav/termora.json
+termora.settings.sync.policy=Synchronisierungsmodus
+termora.settings.sync.policy.manual=Manuell
+termora.settings.sync.policy.on-change=Bei Änderungen
+termora.welcome.contextmenu.show-more-info=Mehr Informationen anzeigen
+termora.transport.table.contextmenu.edit-command=Lege zuerst unter „Einstellungen - SFTP“ einen Bearbeitungsbefehl fest, bevor du Dateien bearbeiten kannst
+termora.transport.table.contextmenu.delete-warning=Bei großen Ordnern kann das Löschen eine Weile dauern
+termora.floating-toolbar.not-supported=Diese Aktion wird nicht unterstützt

--- a/src/main/resources/i18n/messages_de_DE.properties
+++ b/src/main/resources/i18n/messages_de_DE.properties
@@ -1,9 +1,9 @@
 termora.title=Termora
 termora.confirm=Bestätigen
-termora.exit=退出
+termora.exit=Beenden
 termora.cancel=Abbrechen
 termora.copy=Kopieren
-termora.paste=Paste
+termora.paste=Einfügen
 termora.apply=Übernehmen
 termora.save=Speichern
 termora.remove=Löschen
@@ -12,12 +12,12 @@ termora.no=Nein
 termora.date-format=dd.MM.yyyy HH:mm:ss
 termora.finder=Finder
 termora.folder=Ordner
-termora.file=File
+termora.file=Datei
 termora.explorer=Dateimanager
 termora.quit-confirm=Möchtest du {0} wirklich beenden?
 
-termora.regex=Regex
-termora.match-case=Match Case
+termora.regex=Regulärer Ausdruck
+termora.match-case=Groß-/Kleinschreibung beachten
 termora.optional=Optional
 
 # update
@@ -37,29 +37,29 @@ termora.setting=Einstellungen
 
 termora.settings.appearance=Darstellung
 termora.settings.appearance.theme=Design
-termora.settings.appearance.layout=Layout
-termora.settings.appearance.layout.screen=Screen
-termora.settings.appearance.layout.fence=Split
+termora.settings.appearance.layout=Anordnung
+termora.settings.appearance.layout.screen=Bildschirm
+termora.settings.appearance.layout.fence=Geteilt
 termora.settings.appearance.language=Sprache
 termora.settings.appearance.i-want-to-translate=Ich möchte beim Übersetzen helfen
 termora.settings.appearance.follow-system=Systemeinstellung verwenden
 termora.settings.appearance.opacity=Deckkraft
 termora.settings.appearance.background-running=Im Hintergrund weiterlaufen
-termora.settings.appearance.tab-order=Tab Order
+termora.settings.appearance.tab-order=Tab-Reihenfolge
 termora.settings.appearance.confirm-tab-close=Vor dem Schließen von Tabs nachfragen
 
 termora.settings.terminal=Terminal
 termora.settings.terminal.font=Schriftart
-termora.settings.terminal.fallback-font=Fallback Font
+termora.settings.terminal.fallback-font=Ersatzschriftart
 termora.settings.terminal.size=Schriftgröße
 termora.settings.terminal.max-rows=Maximale Zeilen
 termora.settings.terminal.debug=Debug-Modus
 termora.settings.terminal.beep=Signalton
 termora.settings.terminal.hyperlink=Links erkennen
 termora.settings.terminal.select-copy=Beim Markieren kopieren
-termora.settings.terminal.right-click=Right click
-termora.settings.terminal.right-click.copy-and-paste=Copy and Paste
-termora.settings.terminal.right-click.nothing=Nothing
+termora.settings.terminal.right-click=Rechtsklick
+termora.settings.terminal.right-click.copy-and-paste=Kopieren und Einfügen
+termora.settings.terminal.right-click.nothing=Nichts
 termora.settings.terminal.right-click.copy=${termora.copy}
 termora.settings.terminal.cursor-style=Cursor-Stil
 termora.settings.terminal.cursor-blink=Cursor blinken lassen
@@ -77,48 +77,48 @@ termora.settings.about.third-party=Drittanbieter-Abhängigkeiten
 termora.settings.about.termora=<html><b>${termora.title}</b> ({0}) ist ein plattformübergreifender SSH-Client.</html>
 
 termora.settings.plugin=Plugins
-termora.settings.plugin.install=Install
-termora.settings.plugin.installed=Installed
-termora.settings.plugin.marketplace=Marketplace
-termora.settings.plugin.uninstall=Uninstall
-termora.settings.plugin.uninstall-confirm=Are you sure you want to uninstall <b>{0}</b> ?
-termora.settings.plugin.uninstall-failed=Uninstall failed
-termora.settings.plugin.install-failed=Install failed, please try again later
-termora.settings.plugin.install-from-disk=Install Plugin from Disk...
-termora.settings.plugin.manage-plugin-repository=Manage Plugin Repository...
-termora.settings.plugin.install-from-disk-warning=<b>{0}</b> plugin will have access to all your data. Are you sure you want to install it?
-termora.settings.plugin.not-compatible=The plugin <b>{0}</b> is incompatible with the current version. Please reinstall <b>{0}</b>
+termora.settings.plugin.install=Installieren
+termora.settings.plugin.installed=Installiert
+termora.settings.plugin.marketplace=Marktplatz
+termora.settings.plugin.uninstall=Deinstallieren
+termora.settings.plugin.uninstall-confirm=Möchtest du <b>{0}</b> wirklich deinstallieren?
+termora.settings.plugin.uninstall-failed=Deinstallation fehlgeschlagen
+termora.settings.plugin.install-failed=Installation fehlgeschlagen, bitte versuche es später erneut
+termora.settings.plugin.install-from-disk=Plugin von Datenträger installieren...
+termora.settings.plugin.manage-plugin-repository=Plugin-Repository verwalten...
+termora.settings.plugin.install-from-disk-warning=Das Plugin <b>{0}</b> hat Zugriff auf alle deine Daten. Möchtest du es wirklich installieren?
+termora.settings.plugin.not-compatible=Das Plugin <b>{0}</b> ist mit der aktuellen Version nicht kompatibel. Bitte installiere <b>{0}</b> erneut
 
-termora.settings.account=Account
-termora.settings.account.login=Log in
+termora.settings.account=Konto
+termora.settings.account.login=Anmelden
 termora.settings.account.server=Server
-termora.settings.account.wait-login=Waiting for login in the default browser...
-termora.settings.account.locally=locally
-termora.settings.account.lifetime=Lifetime
+termora.settings.account.wait-login=Warte auf Anmeldung im Standardbrowser...
+termora.settings.account.locally=lokal
+termora.settings.account.lifetime=Laufzeit
 termora.settings.account.upgrade=Upgrade
-termora.settings.account.verify=Verify
-termora.settings.account.subscription=Subscription
-termora.settings.account.valid-to=Valid to
-termora.settings.account.synchronization-on=Synchronization on
-termora.settings.account.sync-now=Sync now
-termora.settings.account.logout=Log out
-termora.settings.account.logout-confirm=Are you sure you want to log out?
-termora.settings.account.unsynced-logout-confirm=Unsynced Are you sure you want to log out?
+termora.settings.account.verify=Verifizieren
+termora.settings.account.subscription=Abonnement
+termora.settings.account.valid-to=Gültig bis
+termora.settings.account.synchronization-on=Synchronisierung aktiv
+termora.settings.account.sync-now=Jetzt synchronisieren
+termora.settings.account.logout=Abmelden
+termora.settings.account.logout-confirm=Möchtest du dich wirklich abmelden?
+termora.settings.account.unsynced-logout-confirm=Es gibt nicht synchronisierte Daten. Möchtest du dich wirklich abmelden?
 termora.settings.account.server-singapore=Singapore
-termora.settings.account.server-china=Mainland China
-termora.settings.account.new-server=New Server
-termora.settings.account.deploy-server=Deploy
-termora.settings.account.login-failed=Log in failed, please try again later
+termora.settings.account.server-china=Festlandchina
+termora.settings.account.new-server=Neuer Server
+termora.settings.account.deploy-server=Bereitstellen
+termora.settings.account.login-failed=Anmeldung fehlgeschlagen, bitte versuche es später erneut
 
 
 termora.settings.keymap=Tastatur
 termora.settings.keymap.shortcut=Tastenkürzel
 termora.settings.keymap.action=Aktion
 termora.settings.keymap.already-exists=Das Tastenkürzel [{0}] wird bereits von [{1}] verwendet
-termora.settings.keymap.question=Select a line, press the <font color=rgb({0},{1},{2})> ⌫ (Backspace)</font> key to remove the shortcut
+termora.settings.keymap.question=Wähle eine Zeile aus und drücke die Taste <font color=rgb({0},{1},{2})> ⌫ (Rücktaste)</font>, um das Tastenkürzel zu entfernen
 
 termora.settings.sftp.edit-command=Bearbeitungsbefehl
-termora.settings.sftp.db-click-behavior=Double-click
+termora.settings.sftp.db-click-behavior=Doppelklick
 termora.settings.sftp.fixed-tab=Tab anheften
 termora.settings.sftp.default-directory=Standardverzeichnis
 termora.settings.sftp.preserve-time=Änderungszeit beibehalten
@@ -126,7 +126,7 @@ termora.settings.sftp.preserve-time=Änderungszeit beibehalten
 
 termora.settings.restart.title=Neustart erforderlich
 termora.settings.restart.message=Die Änderungen werden nach einem Neustart wirksam
-termora.settings.restart.manually=Please restart the software manually
+termora.settings.restart.manually=Bitte starte die Anwendung manuell neu
 
 # Find everywhere
 termora.find-everywhere=Suchen
@@ -140,7 +140,7 @@ termora.find-everywhere.quick-command.local-terminal=Lokales Terminal
 
 # Welcome
 termora.welcome.my-hosts=Meine Verbindungen
-termora.welcome.toggle-sidebar=Toggle Sidebar
+termora.welcome.toggle-sidebar=Seitenleiste umschalten
 termora.welcome.contextmenu.connect=Verbinden
 termora.welcome.contextmenu.connect-with=Verbinden mit
 termora.welcome.contextmenu.open-in-new-window=${termora.tabbed.contextmenu.open-in-new-window}
@@ -156,8 +156,8 @@ termora.welcome.contextmenu.new.folder=Ordner
 termora.welcome.contextmenu.new.host=Verbindung
 termora.welcome.contextmenu.new.folder.name=Neuer Ordner
 termora.welcome.contextmenu.property=Eigenschaften
-termora.welcome.contextmenu.show=Show
-termora.welcome.contextmenu.show.more-info=More info
+termora.welcome.contextmenu.show=Anzeigen
+termora.welcome.contextmenu.show.more-info=Weitere Informationen
 termora.welcome.contextmenu.show.tags=${termora.tag}
 termora.welcome.contextmenu.download=Herunterladen
 termora.welcome.contextmenu.import.csv.download-template=Möchtest du Daten importieren oder die Vorlage herunterladen?
@@ -183,18 +183,18 @@ termora.new-host.proxy=Proxy
 
 termora.new-host.terminal=${termora.settings.terminal}
 termora.new-host.terminal.encoding=Zeichencodierung
-termora.new-host.terminal.backspace=Backspace
-termora.new-host.terminal.character-mode=Character-at-a-time
+termora.new-host.terminal.backspace=Rücktaste
+termora.new-host.terminal.character-mode=Zeichenweise
 termora.new-host.terminal.heartbeat-interval=Keepalive-Intervall
-termora.new-host.terminal.timeout=Timeout
+termora.new-host.terminal.timeout=Zeitüberschreitung
 termora.new-host.terminal.startup-commands=Startbefehle
-termora.new-host.terminal.alt-modifier=Alt modifier
-termora.new-host.terminal.alt-modifier.eight-bit=8-bit characters
-termora.new-host.terminal.alt-modifier.by-esc=Characters preceded by ESC
+termora.new-host.terminal.alt-modifier=Alt-Modifikator
+termora.new-host.terminal.alt-modifier.eight-bit=8-Bit-Zeichen
+termora.new-host.terminal.alt-modifier.by-esc=Mit ESC eingeleitete Zeichen
 termora.new-host.terminal.env=Umgebungsvariablen
-termora.new-host.terminal.login-scripts=Login Scripts
-termora.new-host.terminal.expect=Expect
-termora.new-host.terminal.send=Send
+termora.new-host.terminal.login-scripts=Anmeldeskripte
+termora.new-host.terminal.expect=Erwartung
+termora.new-host.terminal.send=Senden
 
 termora.new-host.serial=Serielle Verbindung
 termora.new-host.serial.port=Port
@@ -213,33 +213,33 @@ termora.new-host.tunneling.add=Hinzufügen
 termora.new-host.tunneling.edit=${termora.keymgr.edit}
 termora.new-host.tunneling.delete=${termora.remove}
 
-termora.new-host.rdp.desktop-placeholder=Default full screen (e.g. 1920×1080)
-termora.new-host.rdp.resolution=Resolution
+termora.new-host.rdp.desktop-placeholder=Standard-Vollbild (z. B. 1920×1080)
+termora.new-host.rdp.resolution=Auflösung
 
 
-termora.new-host.wsl.distribution=DistroName
+termora.new-host.wsl.distribution=Distributionsname
 
 termora.new-host.test-connection=Verbindung testen
 termora.new-host.test-connection-successful=Verbindung erfolgreich
 
 
-termora.new-host.jump-hosts=Jump-Hosts
+termora.new-host.jump-hosts=Sprung-Hosts
 
 # Key manager
 termora.keymgr.title=Schlüsselverwaltung
-termora.keymgr.my-keys=My keys
+termora.keymgr.my-keys=Meine Schlüssel
 termora.keymgr.generate=Erstellen
 termora.keymgr.import=Importieren
 termora.keymgr.export=Exportieren
 termora.keymgr.edit=Bearbeiten
-termora.keymgr.private-key=Private Key
+termora.keymgr.private-key=Privater Schlüssel
 termora.keymgr.delete-warning=Möchtest du diesen Schlüssel wirklich löschen?
 termora.keymgr.table.name=Name
 termora.keymgr.table.type=Typ
 termora.keymgr.table.length=Länge
 termora.keymgr.table.remark=Notiz
-termora.keymgr.export-done=The export was successful
-termora.keymgr.export-done-open-folder=The export was successful. Do you want to open the folder?
+termora.keymgr.export-done=Der export war erfolgreich
+termora.keymgr.export-done-open-folder=Der export war erfolgreich. Möchtest du den Ordner öffnen?
 
 termora.keymgr.ssh-copy-id.number=Hosts: [{0}]    Öffentliche Schlüssel: [{1}]
 termora.keymgr.ssh-copy-id.successful=${termora.terminal.copied}
@@ -249,11 +249,11 @@ termora.keymgr.ssh-copy-id.end=Öffentlicher Schlüssel wurde kopiert
 
 # Tabbed
 termora.tabbed.contextmenu.rename=Umbenennen
-termora.tabbed.contextmenu.select-host=Select Host
+termora.tabbed.contextmenu.select-host=Host auswählen
 termora.tabbed.contextmenu.sftp-command=SFTP-Terminal
 termora.tabbed.contextmenu.sftp-not-install=SFTP wurde nicht gefunden. Bitte installiere SFTP und versuche es erneut
 termora.tabbed.contextmenu.clone=Duplizieren
-termora.tabbed.contextmenu.clone-session=Clone Session
+termora.tabbed.contextmenu.clone-session=Session duplizieren
 termora.tabbed.contextmenu.open-in-new-window=In neuem Fenster öffnen
 termora.tabbed.contextmenu.close=Schließen
 termora.tabbed.contextmenu.close-other-tabs=Andere Tabs schließen
@@ -265,8 +265,8 @@ termora.tabbed.tab.close-prompt=Möchtest du diesen Tab wirklich schließen?
 # Terminal logger
 termora.terminal-logger=Terminal-Protokoll
 termora.terminal-logger.start-recording=Aufzeichnung starten
-termora.terminal-logger.plain-text=Plain text
-termora.terminal-logger.styled-text=Styled text
+termora.terminal-logger.plain-text=Klartext
+termora.terminal-logger.styled-text=Formatierter Text
 termora.terminal-logger.stop-recording=Aufzeichnung stoppen
 termora.terminal-logger.open-log-viewer=Protokoll anzeigen
 termora.terminal-logger.open-in-folder=In {0} öffnen
@@ -274,11 +274,11 @@ termora.terminal-logger.open-in-folder=In {0} öffnen
 
 # Highlight
 termora.highlight=Schlüsselwort-Hervorhebung
-termora.highlight.default-set=Default Set
+termora.highlight.default-set=Standardsatz
 termora.highlight.text-color=Textfarbe
 termora.highlight.background-color=Hintergrundfarbe
 termora.highlight.keyword=Schlüsselwort
-termora.highlight.my-keyword=My Keyword
+termora.highlight.my-keyword=Mein Schlüsselwort
 termora.highlight.preview=Vorschau
 termora.highlight.description=Notiz
 termora.highlight.bold=Fett
@@ -288,8 +288,8 @@ termora.highlight.line-through=Durchgestrichen
 
 # tag
 termora.tag=Tags
-termora.tag.my-tags=My tags
-termora.tag.manage-tags=Manage tags
+termora.tag.my-tags=Meine Tags
+termora.tag.manage-tags=Tags verwalten
 
 # Macro
 termora.macro=Makro
@@ -300,7 +300,7 @@ termora.macro.manager=Makros verwalten
 termora.macro.run=Ausführen
 
 # Snippets
-termora.snippet=Snippet
+termora.snippet=Textbaustein
 termora.snippet.title=Code-Snippet
 
 # Tools
@@ -311,12 +311,12 @@ termora.transport.local=Lokal
 termora.transport.file-already-exists=Die Datei {0} existiert bereits
 
 
-termora.transport.toolbar.prev=Backward
-termora.transport.toolbar.home=Home Folder
-termora.transport.toolbar.next=Forward
-termora.transport.toolbar.parent=Parent Folder
-termora.transport.toolbar.show-hide=Show/Hide Folders
-termora.transport.toolbar.refresh=Refresh Folder
+termora.transport.toolbar.prev=Zurück
+termora.transport.toolbar.home=Startordner
+termora.transport.toolbar.next=Weiter
+termora.transport.toolbar.parent=Übergeordneter Ordner
+termora.transport.toolbar.show-hide=Ordner ein-/ausblenden
+termora.transport.toolbar.refresh=Ordner aktualisieren
 
 termora.transport.bookmarks=Lesezeichen verwalten
 termora.transport.bookmarks.up=Nach oben
@@ -340,11 +340,11 @@ termora.transport.table.contextmenu.delete=${termora.remove}
 termora.transport.table.contextmenu.rm-warning=Das Löschen mit rm -rf ist riskant und kann nicht einfach rückgängig gemacht werden
 termora.transport.table.contextmenu.change-permissions=Berechtigungen ändern...
 termora.transport.table.contextmenu.refresh=Aktualisieren
-termora.transport.table.contextmenu.compress=Compress
-termora.transport.table.contextmenu.extract=Extract
-termora.transport.table.contextmenu.extract.here=Extract here
-termora.transport.table.contextmenu.extract.single=Extract to {0}\\
-termora.transport.table.contextmenu.extract.multi=Extract to *\\*
+termora.transport.table.contextmenu.compress=Komprimieren
+termora.transport.table.contextmenu.extract=Entpacken
+termora.transport.table.contextmenu.extract.here=Hier entpacken
+termora.transport.table.contextmenu.extract.single=Entpacken nach {0}\\
+termora.transport.table.contextmenu.extract.multi=Entpacken nach *\\*
 termora.transport.table.contextmenu.new=${termora.welcome.contextmenu.new}
 termora.transport.table.contextmenu.new.folder=${termora.welcome.contextmenu.new.folder.name}
 termora.transport.table.contextmenu.new.file=${termora.transport.table.contextmenu.new}Datei
@@ -352,7 +352,7 @@ termora.transport.table.contextmenu.new.file=${termora.transport.table.contextme
 # Permission
 termora.transport.permissions=Berechtigungen ändern
 termora.transport.permissions.file-folder-permissions=Datei- und Ordnerberechtigungen
-termora.transport.permissions.octal-mode=Octal mode
+termora.transport.permissions.octal-mode=Oktalmodus
 termora.transport.permissions.read=Lesen
 termora.transport.permissions.write=Schreiben
 termora.transport.permissions.execute=Ausführen
@@ -361,7 +361,7 @@ termora.transport.permissions.group=Gruppe
 termora.transport.permissions.others=Andere
 termora.transport.permissions.include-subfolder=Unterordner einbeziehen
 
-termora.transport.sftp=Transfer
+termora.transport.sftp=Übertragung
 termora.transport.sftp.retry=Erneut versuchen
 termora.transport.sftp.select-another-host=Anderen Host auswählen
 termora.transport.sftp.select-host=Host auswählen
@@ -370,7 +370,7 @@ termora.transport.sftp.closed=Die Verbindung wurde geschlossen
 termora.transport.sftp.close-tab=Es laufen noch Übertragungen. Möchtest du alle Übertragungen abbrechen und diese Sitzung schließen?
 termora.transport.sftp.close-tab-has-active-session=Diese Sitzung ist noch aktiv. Möchtest du alle Sitzungen schließen?
 termora.transport.sftp.status.transporting=Wird übertragen
-termora.transport.sftp.status.deleting=Deleting
+termora.transport.sftp.status.deleting=Wird gelöscht
 termora.transport.sftp.status.waiting=Wartet
 termora.transport.sftp.status.done=Abgeschlossen
 termora.transport.sftp.status.failed=Fehlgeschlagen
@@ -410,7 +410,7 @@ termora.toolbar.customize-toolbar=Werkzeugleiste anpassen...
 
 # Actions
 termora.actions.copy-from-terminal=Aus Terminal kopieren
-termora.actions.focus-mode=Focus Mode
+termora.actions.focus-mode=Fokusmodus
 termora.actions.paste-to-terminal=In Terminal einfügen
 termora.actions.select-all-in-terminal=Alles im Terminal auswählen
 termora.actions.open-terminal-find=Im Terminal suchen
@@ -419,7 +419,7 @@ termora.actions.zoom-in-terminal=Terminal vergrößern
 termora.actions.zoom-out-terminal=Terminal verkleinern
 termora.actions.zoom-reset-terminal=Terminal-Zoom zurücksetzen
 termora.actions.open-local-terminal=Lokales Terminal öffnen
-termora.actions.quick-connect=Quick Connect
+termora.actions.quick-connect=Schnellverbindung
 termora.actions.open-find-everywhere=Globale Suche öffnen
 termora.actions.open-new-window=Neues Fenster öffnen
 termora.actions.clear-screen=Terminal leeren
@@ -433,18 +433,18 @@ termora.terminal.channel-disconnected=Terminalverbindung getrennt.
 termora.terminal.channel-reconnect=Drücke {0}, um die Verbindung erneut herzustellen.
 
 # protocol
-termora.protocol.not-supported={0} protocol is not supported, you may need to install the plugin
+termora.protocol.not-supported=Das Protokoll {0} wird nicht unterstützt. Möglicherweise musst du das Plugin installieren
 
 # Visual Window
 termora.visual-window.system-information=Systeminformationen
 termora.visual-window.system-information.mem=Arbeitsspeicher
-termora.visual-window.system-information.swap=Swap
+termora.visual-window.system-information.swap=Auslagerungsspeicher
 termora.visual-window.system-information.filesystem=Dateisystem
 termora.visual-window.system-information.used-total=Belegt / Gesamt
-termora.visual-window.toggle-window=Toggle window
-termora.visual-window.transport.question=More Features
+termora.visual-window.toggle-window=Fenster ein-/ausblenden
+termora.visual-window.transport.question=Weitere Funktionen
 
-termora.visual-window.command-history=Command History
+termora.visual-window.command-history=Befehlsverlauf
 
 
 termora.visual-window.nvidia-smi=NVIDIA SMI

--- a/src/test/kotlin/app/termora/I18nTest.kt
+++ b/src/test/kotlin/app/termora/I18nTest.kt
@@ -23,4 +23,10 @@ class I18nTest {
         val bundle = ResourceBundle.getBundle("i18n/messages", LocaleUtils.toLocale("zh_TW"))
         assertEquals(bundle.getString("termora.confirm"), "確定")
     }
+
+    @Test
+    fun test_de_DE() {
+        val bundle = ResourceBundle.getBundle("i18n/messages", LocaleUtils.toLocale("de_DE"))
+        assertEquals(bundle.getString("termora.settings.appearance.language"), "Sprache")
+    }
 }

--- a/src/test/kotlin/app/termora/account/TeamTest.kt
+++ b/src/test/kotlin/app/termora/account/TeamTest.kt
@@ -12,7 +12,7 @@ class TeamTest {
                     id = "test",
                     name = "test",
                     secretKey = byteArrayOf(1, 123, 123, 123, 123, 123, 123, 123, 123),
-                    role = TeamRole.Member
+                    role = TeamRole.Member.name
                 )
             )
         )


### PR DESCRIPTION
This change adds messages_de_DE.properties and registers de_DE as a supported language so German can be selected in the application UI.

It also:
- adds a localization test for de_DE
- updates the README language links to include the new German README 
- fixes TeamTest so the test suite works with the current Team.role type