### PR TITLE
fix(terminal): support Shift+Tab and Shift+Enter on Windows for CLI tools

### DIFF
--- a/src/main/kotlin/app/termora/terminal/KeyEncoderImpl.kt
+++ b/src/main/kotlin/app/termora/terminal/KeyEncoderImpl.kt
@@ -31,6 +31,18 @@ open class KeyEncoderImpl(private val terminal: Terminal) : KeyEncoder, DataList
         // Ctrl + C: 0x7F ASCII Delete
         putCode(TerminalKeyEvent(keyCode = KeyEvent.VK_BACK_SPACE), String(byteArrayOf(0x7F)))
 
+        // Shift + Tab -> CBT (Cursor Backward Tabulation)
+        putCode(
+            TerminalKeyEvent(keyCode = KeyEvent.VK_TAB, modifiers = TerminalEvent.SHIFT_MASK),
+            encode = "${ControlCharacters.ESC}[Z"
+        )
+
+        // Shift + Enter -> CSI-u modified Enter.
+        putCode(
+            TerminalKeyEvent(keyCode = KeyEvent.VK_ENTER, modifiers = TerminalEvent.SHIFT_MASK),
+            encode = "${ControlCharacters.ESC}[13;2u"
+        )
+
         // Enter
         if (terminalModel.getData(DataKey.AutoNewline, false)) {
             putCode(TerminalKeyEvent(keyCode = 10), encode = "\r\n")


### PR DESCRIPTION
## Summary

Fixes missing **Shift+Tab** and **Shift+Enter** key mappings on Windows, which prevented these shortcuts from working in interactive CLI tools such as **Claude Code**.

Previously, Termora did not encode these modifier combinations into the escape sequences that TUI/CLI applications expect. As a result:

- **Shift+Tab** could not be used for mode switching / reverse tab navigation
- **Shift+Enter** could not be used to insert a newline within a session input

This change adds explicit mappings in `KeyEncoderImpl`:

| Key | Sequence | Purpose |
|-----|----------|---------|
| Shift+Tab | `ESC [ Z` | CBT (Cursor Backward Tabulation) |
| Shift+Enter | `ESC [ 13;2u` | CSI-u modified Enter |

## Problem

On Windows, when using Termora with interactive CLI tools (e.g. Claude Code):

1. Pressing **Shift+Tab** did not trigger mode switching or backward tab behavior
2. Pressing **Shift+Enter** did not insert a newline in the input area

These tools rely on specific terminal escape sequences for modified keys. Without proper encoding, the key events were not delivered correctly to the running process.

## Solution

Add missing key bindings in `KeyEncoderImpl.kt` so that Shift+Tab and Shift+Enter are translated into the standard sequences expected by modern shell and TUI applications.

## Test plan

- [x] On **Windows**, open a terminal session in Termora
- [x] In **Claude Code** (or similar TUI CLI):
  - [x] Verify **Shift+Tab** triggers mode switching / reverse tab
  - [x] Verify **Shift+Enter** inserts a newline in the input area
- [x] Confirm normal **Tab** and **Enter** behavior is unchanged
- [ ] (Optional) Smoke test on macOS/Linux to ensure no regression