### PR TITLE
feat: add export/import functionality for snippets and hosts

### DIFF
--- a/src/main/kotlin/app/termora/HostManager.kt
+++ b/src/main/kotlin/app/termora/HostManager.kt
@@ -1,10 +1,15 @@
 package app.termora
 
 import app.termora.Application.ohMyJson
+import app.termora.account.AccountManager
 import app.termora.database.Data
 import app.termora.database.DataType
 import app.termora.database.DatabaseChangedExtension
 import app.termora.database.DatabaseManager
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import java.io.File
+import java.nio.file.Files
 
 
 class HostManager private constructor() : Disposable {
@@ -62,5 +67,63 @@ class HostManager private constructor() : Disposable {
         if (data.deleted) return null
         return ohMyJson.decodeFromString(data.data)
     }
+
+    /**
+     * 导出所有主机配置到JSON文件
+     */
+    fun exportHosts(file: File) {
+        val hosts = hosts()
+        val exportData = HostExportData(
+            version = 1,
+            exportDate = System.currentTimeMillis(),
+            hosts = hosts.map { it.copy(deleted = false) } // 导出时不包含deleted标记
+        )
+        val json = ohMyJson.encodeToString(exportData)
+        Files.writeString(file.toPath(), json)
+    }
+
+    /**
+     * 从JSON文件导入主机配置
+     * @param file 要导入的文件
+     * @param replaceAll true=替换所有现有主机，false=合并（保留现有主机）
+     * @return 导入的主机数量
+     */
+    fun importHosts(file: File, replaceAll: Boolean): Int {
+        assertEventDispatchThread()
+        val json = Files.readString(file.toPath())
+        val importData = ohMyJson.decodeFromString<HostExportData>(json)
+
+        // 获取当前账户的 ownerId
+        // 优先使用账户管理器的ID，如果是本地账户则使用 "0"
+        val currentOwnerId = if (AccountManager.getInstance().isLocally()) {
+            "0"
+        } else {
+            AccountManager.getInstance().getAccountId()
+        }
+        val currentOwnerType = "User"
+
+        if (replaceAll) {
+            // 删除所有现有主机
+            hosts().forEach { removeHost(it.id) }
+        }
+
+        // 导入新主机，更新 ownerId 和 ownerType 为当前用户
+        importData.hosts.forEach { host ->
+            val updatedHost = host.copy(
+                ownerId = currentOwnerId,
+                ownerType = currentOwnerType
+            )
+            addHost(updatedHost, DatabaseChangedExtension.Source.User)
+        }
+
+        return importData.hosts.size
+    }
+
+    @Serializable
+    private data class HostExportData(
+        val version: Int,
+        val exportDate: Long,
+        val hosts: List<Host>
+    )
 
 }

--- a/src/main/kotlin/app/termora/snippet/SnippetManager.kt
+++ b/src/main/kotlin/app/termora/snippet/SnippetManager.kt
@@ -8,6 +8,10 @@ import app.termora.database.Data
 import app.termora.database.DataType
 import app.termora.database.DatabaseManager
 import app.termora.database.OwnerType
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import java.io.File
+import java.nio.file.Files
 
 
 class SnippetManager private constructor() {
@@ -54,5 +58,48 @@ class SnippetManager private constructor() {
             .sortedWith(compareBy<Snippet> { if (it.type == SnippetType.Folder) 0 else 1 }.thenBy { it.sort })
     }
 
+    /**
+     * 导出所有代码片段到JSON文件
+     */
+    fun exportSnippets(file: File) {
+        val snippets = snippets()
+        val exportData = SnippetExportData(
+            version = 1,
+            exportDate = System.currentTimeMillis(),
+            snippets = snippets.map { it.copy(deleted = false) } // 导出时不包含deleted标记
+        )
+        val json = ohMyJson.encodeToString(exportData)
+        Files.writeString(file.toPath(), json)
+    }
 
+    /**
+     * 从JSON文件导入代码片段
+     * @param file 要导入的文件
+     * @param replaceAll true=替换所有现有片段，false=合并（保留现有片段）
+     * @return 导入的片段数量
+     */
+    fun importSnippets(file: File, replaceAll: Boolean): Int {
+        assertEventDispatchThread()
+        val json = Files.readString(file.toPath())
+        val importData = ohMyJson.decodeFromString<SnippetExportData>(json)
+
+        if (replaceAll) {
+            // 删除所有现有片段
+            snippets().forEach { removeSnippet(it.id) }
+        }
+
+        // 导入新片段
+        importData.snippets.forEach { snippet ->
+            addSnippet(snippet)
+        }
+
+        return importData.snippets.size
+    }
+
+    @Serializable
+    private data class SnippetExportData(
+        val version: Int,
+        val exportDate: Long,
+        val snippets: List<Snippet>
+    )
 }

--- a/src/main/kotlin/app/termora/snippet/SnippetTree.kt
+++ b/src/main/kotlin/app/termora/snippet/SnippetTree.kt
@@ -48,6 +48,9 @@ class SnippetTree : SimpleTree() {
         val expandAll = popupMenu.add(I18n.getString("termora.welcome.contextmenu.expand-all"))
         val colspanAll = popupMenu.add(I18n.getString("termora.welcome.contextmenu.collapse-all"))
         popupMenu.addSeparator()
+        val exportSnippets = popupMenu.add(I18n.getString("termora.snippet.export"))
+        val importSnippets = popupMenu.add(I18n.getString("termora.snippet.import"))
+        popupMenu.addSeparator()
 
         newFolder.addActionListener {
             val snippet = Snippet(
@@ -108,6 +111,86 @@ class SnippetTree : SimpleTree() {
                 }
             }
         })
+
+        exportSnippets.addActionListener {
+            val fileChooser = javax.swing.JFileChooser()
+            fileChooser.dialogTitle = I18n.getString("termora.snippet.export")
+            fileChooser.fileFilter = javax.swing.filechooser.FileNameExtensionFilter("JSON Files", "json")
+            fileChooser.selectedFile = java.io.File("snippets-${System.currentTimeMillis()}.json")
+
+            if (fileChooser.showSaveDialog(SwingUtilities.getWindowAncestor(this)) == javax.swing.JFileChooser.APPROVE_OPTION) {
+                try {
+                    var file = fileChooser.selectedFile
+                    if (!file.name.endsWith(".json")) {
+                        file = java.io.File(file.parentFile, file.name + ".json")
+                    }
+                    snippetManager.exportSnippets(file)
+                    OptionPane.showMessageDialog(
+                        SwingUtilities.getWindowAncestor(this),
+                        I18n.getString("termora.snippet.export.success", file.absolutePath),
+                        I18n.getString("termora.snippet.export"),
+                        JOptionPane.INFORMATION_MESSAGE
+                    )
+                } catch (e: Exception) {
+                    OptionPane.showMessageDialog(
+                        SwingUtilities.getWindowAncestor(this),
+                        I18n.getString("termora.snippet.export.error", e.message ?: "Unknown error"),
+                        I18n.getString("termora.snippet.export"),
+                        JOptionPane.ERROR_MESSAGE
+                    )
+                }
+            }
+        }
+
+        importSnippets.addActionListener {
+            val fileChooser = javax.swing.JFileChooser()
+            fileChooser.dialogTitle = I18n.getString("termora.snippet.import")
+            fileChooser.fileFilter = javax.swing.filechooser.FileNameExtensionFilter("JSON Files", "json")
+
+            if (fileChooser.showOpenDialog(SwingUtilities.getWindowAncestor(this)) == javax.swing.JFileChooser.APPROVE_OPTION) {
+                try {
+                    val file = fileChooser.selectedFile
+
+                    // 询问导入模式
+                    val options: Array<Any> = arrayOf(
+                        I18n.getString("termora.snippet.import.merge.merge"),
+                        I18n.getString("termora.snippet.import.merge.replace")
+                    )
+                    val choice = OptionPane.showConfirmDialog(
+                        SwingUtilities.getWindowAncestor(this),
+                        I18n.getString("termora.snippet.import.merge.message"),
+                        I18n.getString("termora.snippet.import.merge.title"),
+                        JOptionPane.YES_NO_OPTION,
+                        JOptionPane.QUESTION_MESSAGE,
+                        null,
+                        options,
+                        options[0]
+                    )
+
+                    if (choice == -1) return@addActionListener
+
+                    val replaceAll = (choice == 1)
+                    val count = snippetManager.importSnippets(file, replaceAll)
+
+                    // 刷新树
+                    simpleTreeModel.reload()
+
+                    OptionPane.showMessageDialog(
+                        SwingUtilities.getWindowAncestor(this),
+                        I18n.getString("termora.snippet.import.success", count),
+                        I18n.getString("termora.snippet.import"),
+                        JOptionPane.INFORMATION_MESSAGE
+                    )
+                } catch (e: Exception) {
+                    OptionPane.showMessageDialog(
+                        SwingUtilities.getWindowAncestor(this),
+                        I18n.getString("termora.snippet.import.error", e.message ?: "Unknown error"),
+                        I18n.getString("termora.snippet.import"),
+                        JOptionPane.ERROR_MESSAGE
+                    )
+                }
+            }
+        }
 
 
         rename.isEnabled = lastNode != simpleTreeModel.root

--- a/src/main/kotlin/app/termora/tree/NewHostTree.kt
+++ b/src/main/kotlin/app/termora/tree/NewHostTree.kt
@@ -284,6 +284,9 @@ class NewHostTree : SimpleTree(), Disposable {
         popupMenu.add(importMenu)
         popupMenu.add(newMenu)
         popupMenu.addSeparator()
+        val exportHosts = popupMenu.add(I18n.getString("termora.host.export"))
+        val importHostsJson = popupMenu.add(I18n.getString("termora.host.import"))
+        popupMenu.addSeparator()
         val tagsMenu = popupMenu.add(JMenu(I18n.getString("termora.tag"))) as JMenu
         val showMenu = popupMenu.add(JMenu(I18n.getString("termora.welcome.contextmenu.show"))) as JMenu
         val showMoreInfo = showMenu.add(JCheckBoxMenuItem(I18n.getString("termora.welcome.contextmenu.show.more-info")))
@@ -306,6 +309,87 @@ class NewHostTree : SimpleTree(), Disposable {
         finalShellMenu.addActionListener { importHosts(lastNode, ImportType.FinalShell) }
         csvMenu.addActionListener { importHosts(lastNode, ImportType.CSV) }
         windTermMenu.addActionListener { importHosts(lastNode, ImportType.WindTerm) }
+
+        exportHosts.addActionListener {
+            val fileChooser = JFileChooser()
+            fileChooser.dialogTitle = I18n.getString("termora.host.export")
+            fileChooser.fileFilter = FileNameExtensionFilter("JSON Files", "json")
+            fileChooser.selectedFile = File("hosts-${System.currentTimeMillis()}.json")
+
+            if (fileChooser.showSaveDialog(SwingUtilities.getWindowAncestor(this)) == JFileChooser.APPROVE_OPTION) {
+                try {
+                    var file = fileChooser.selectedFile
+                    if (!file.name.endsWith(".json")) {
+                        file = File(file.parentFile, file.name + ".json")
+                    }
+                    HostManager.getInstance().exportHosts(file)
+                    OptionPane.showMessageDialog(
+                        SwingUtilities.getWindowAncestor(this),
+                        I18n.getString("termora.host.export.success", file.absolutePath),
+                        I18n.getString("termora.host.export"),
+                        JOptionPane.INFORMATION_MESSAGE
+                    )
+                } catch (e: Exception) {
+                    OptionPane.showMessageDialog(
+                        SwingUtilities.getWindowAncestor(this),
+                        I18n.getString("termora.host.export.error", e.message ?: "Unknown error"),
+                        I18n.getString("termora.host.export"),
+                        JOptionPane.ERROR_MESSAGE
+                    )
+                }
+            }
+        }
+
+        importHostsJson.addActionListener {
+            val fileChooser = JFileChooser()
+            fileChooser.dialogTitle = I18n.getString("termora.host.import")
+            fileChooser.fileFilter = FileNameExtensionFilter("JSON Files", "json")
+
+            if (fileChooser.showOpenDialog(SwingUtilities.getWindowAncestor(this)) == JFileChooser.APPROVE_OPTION) {
+                try {
+                    val file = fileChooser.selectedFile
+
+                    // 询问导入模式
+                    val options: Array<Any> = arrayOf(
+                        I18n.getString("termora.host.import.merge.merge"),
+                        I18n.getString("termora.host.import.merge.replace")
+                    )
+                    val choice = OptionPane.showConfirmDialog(
+                        SwingUtilities.getWindowAncestor(this),
+                        I18n.getString("termora.host.import.merge.message"),
+                        I18n.getString("termora.host.import.merge.title"),
+                        JOptionPane.YES_NO_OPTION,
+                        JOptionPane.QUESTION_MESSAGE,
+                        null,
+                        options,
+                        options[0]
+                    )
+
+                    if (choice == -1) return@addActionListener
+
+                    val replaceAll = (choice == 1)
+                    val count = HostManager.getInstance().importHosts(file, replaceAll)
+
+                    // 刷新树
+                    simpleTreeModel.reload()
+
+                    OptionPane.showMessageDialog(
+                        SwingUtilities.getWindowAncestor(this),
+                        I18n.getString("termora.host.import.success", count),
+                        I18n.getString("termora.host.import"),
+                        JOptionPane.INFORMATION_MESSAGE
+                    )
+                } catch (e: Exception) {
+                    OptionPane.showMessageDialog(
+                        SwingUtilities.getWindowAncestor(this),
+                        I18n.getString("termora.host.import.error", e.message ?: "Unknown error"),
+                        I18n.getString("termora.host.import"),
+                        JOptionPane.ERROR_MESSAGE
+                    )
+                }
+            }
+        }
+
         open.addActionListener { openHosts(it, false) }
         openInNewWindow.addActionListener { openHosts(it, true) }
         openWithSFTP.addActionListener { openWithSFTP(it) }

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -166,6 +166,18 @@ termora.welcome.contextmenu.import.csv.download-template-done-open-folder=Downlo
 termora.welcome.contextmenu.import.xshell-folder-empty=The folder does not contain any *.xsh files, Please select the correct Xshell Sessions directory
 termora.welcome.contextmenu.import.finalshell-folder-empty=The folder does not contain any *_connect_config.json files, Please select the correct FinalShell directory
 
+# Host Export/Import
+termora.host.export=Export Hosts
+termora.host.import=Import Hosts
+termora.host.export.success=Hosts exported successfully to {0}
+termora.host.import.success=Successfully imported {0} hosts
+termora.host.export.error=Error exporting hosts: {0}
+termora.host.import.error=Error importing hosts: {0}
+termora.host.import.merge.title=Import Mode
+termora.host.import.merge.message=Choose import method:
+termora.host.import.merge.replace=Replace all existing hosts
+termora.host.import.merge.merge=Merge (keep existing hosts)
+
 # New Host
 termora.new-host.title=Create a new host
 termora.new-host.general=General
@@ -302,6 +314,17 @@ termora.macro.run=Run
 # Snippets
 termora.snippet=Snippet
 termora.snippet.title=Snippets
+termora.snippet.export=Export Snippets
+termora.snippet.import=Import Snippets
+termora.snippet.export.success=Snippets exported successfully to {0}
+termora.snippet.import.success=Successfully imported {0} snippets
+termora.snippet.export.error=Error exporting snippets: {0}
+termora.snippet.import.error=Error importing snippets: {0}
+termora.snippet.import.confirm=Confirm Import
+termora.snippet.import.merge.title=Import Mode
+termora.snippet.import.merge.message=Choose import method:
+termora.snippet.import.merge.replace=Replace all existing snippets
+termora.snippet.import.merge.merge=Merge (keep existing snippets)
 
 # Tools
 termora.tools.multiple=Send command to the current window sessions

--- a/src/main/resources/i18n/messages_zh_CN.properties
+++ b/src/main/resources/i18n/messages_zh_CN.properties
@@ -159,6 +159,18 @@ termora.welcome.contextmenu.import.csv.download-template-done-open-folder=下载
 termora.welcome.contextmenu.import.xshell-folder-empty=该文件夹不包含 *.xsh 文件，请选择正确的 Xshell 会话目录
 termora.welcome.contextmenu.import.finalshell-folder-empty=该文件夹不包含 *_connect_config.json 文件，请选择正确的 FinalShell 配置目录
 
+# Host Export/Import
+termora.host.export=导出主机
+termora.host.import=导入主机
+termora.host.export.success=主机已成功导出到 {0}
+termora.host.import.success=成功导入 {0} 个主机
+termora.host.export.error=导出主机时出错: {0}
+termora.host.import.error=导入主机时出错: {0}
+termora.host.import.merge.title=导入模式
+termora.host.import.merge.message=选择导入方式：
+termora.host.import.merge.replace=替换所有现有主机
+termora.host.import.merge.merge=合并（保留现有主机）
+
 # New Host
 termora.new-host.title=新建主机
 termora.new-host.general=属性
@@ -300,6 +312,17 @@ termora.macro.run=运行
 # Snippets
 termora.snippet=片段
 termora.snippet.title=代码片段
+termora.snippet.export=导出代码片段
+termora.snippet.import=导入代码片段
+termora.snippet.export.success=代码片段已成功导出到 {0}
+termora.snippet.import.success=成功导入 {0} 个代码片段
+termora.snippet.export.error=导出代码片段时出错: {0}
+termora.snippet.import.error=导入代码片段时出错: {0}
+termora.snippet.import.confirm=确认导入
+termora.snippet.import.merge.title=导入模式
+termora.snippet.import.merge.message=选择导入方式：
+termora.snippet.import.merge.replace=替换所有现有片段
+termora.snippet.import.merge.merge=合并（保留现有片段）
 
 
 


### PR DESCRIPTION
- Add export/import for code snippets with JSON format
- Add export/import for host configurations with JSON format
- Support merge and replace modes for importing
- Preserve folder hierarchy and complete metadata
- Fix ownerId handling for local and cloud accounts
- Add internationalization support (zh_CN, en)