### PR TITLE
feat: termora-cli — a CLI for AI agents to reuse saved SSH hosts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -248,11 +248,11 @@ tasks.register<Copy>("copy-dependencies") {
                 FileUtils.forceMkdir(targetDir)
                 if (os.isWindows) {
                     // @formatter:off
-                    exec { commandLine("unzip", "-j" , "-o", file.absolutePath, "resources/*win/${myArchName}/*", "-d", targetDir.absolutePath) }
+                    exec { commandLine("unzip", "-j" , "-o", file.absolutePath, "resources/com/pty4j/native/win/${myArchName}/*", "-d", targetDir.absolutePath) }
                     // @formatter:on
                 } else if (os.isLinux) {
                     // @formatter:off
-                    exec { commandLine("unzip", "-j" , "-o", file.absolutePath, "resources/*linux/${myArchName}/*", "-d", targetDir.absolutePath) }
+                    exec { commandLine("unzip", "-j" , "-o", file.absolutePath, "resources/com/pty4j/native/linux/${myArchName}/*", "-d", targetDir.absolutePath) }
                     // @formatter:on
                 } else if (os.isMacOsX) {
                     // @formatter:off
@@ -378,6 +378,8 @@ tasks.register<Exec>("jpackage") {
         "-Dapp-version=${project.version}",
         "-Drelease-date=${DateFormatUtils.format(Date(), "yyyy-MM-dd")}",
         "--add-exports java.base/sun.nio.ch=ALL-UNNAMED",
+        // 抑制 JDK 24+ 的 native-access 警告（sqlite/jna/pty4j 用 System.load），并为未来 JDK 的强制限制做准备
+        "--enable-native-access=ALL-UNNAMED",
     )
 
     options.add("-Dsun.java2d.metal=true")
@@ -450,6 +452,19 @@ tasks.register<Exec>("jpackage") {
         arguments.add("--mac-signing-key-user-name")
         arguments.add(macOSSignUsername)
     }
+
+    // ===== termora-cli 第二入口（CLI）=====
+    // 动态生成 launcher properties：Windows 加 win-console=true 让 CLI 有控制台/可见 stdout。
+    // 写到 build 目录，避免放进 src/main/resources 被打进 jar。
+    val cliLauncherProps = buildDir.file("jpackage-launchers/termora-cli.properties").asFile
+    cliLauncherProps.parentFile.mkdirs()
+    cliLauncherProps.writeText(
+        buildString {
+            append("main-class=app.termora.cli.CliMainKt\n")
+            if (os.isWindows) append("win-console=true\n")
+        }
+    )
+    arguments.addAll(listOf("--add-launcher", "termora-cli=${cliLauncherProps.absolutePath}"))
 
     commandLine(arguments)
 

--- a/src/main/kotlin/app/termora/ApplicationInitializr.kt
+++ b/src/main/kotlin/app/termora/ApplicationInitializr.kt
@@ -71,61 +71,63 @@ class ApplicationInitializr {
     }
 
 
-    private fun setupNativeLibraries() {
-        val appPath = Application.getAppPath()
-        if (StringUtils.isBlank(appPath)) {
-            return
-        }
-
-        var contents = File(appPath)
-        if (SystemUtils.IS_OS_MAC_OSX || SystemUtils.IS_OS_LINUX) {
-            contents = contents.parentFile?.parentFile ?: return
-            if (SystemUtils.IS_OS_LINUX) {
-                contents = File(contents, "lib")
+    companion object {
+        internal fun setupNativeLibraries() {
+            val appPath = Application.getAppPath()
+            if (StringUtils.isBlank(appPath)) {
+                return
             }
-        } else if (SystemUtils.IS_OS_WINDOWS) {
-            contents = contents.parentFile ?: return
-        }
 
-        val dylib = FileUtils.getFile(contents, "app", "dylib")
-        if (dylib.exists().not()) {
-            return
-        }
+            var contents = File(appPath)
+            if (SystemUtils.IS_OS_MAC_OSX || SystemUtils.IS_OS_LINUX) {
+                contents = contents.parentFile?.parentFile ?: return
+                if (SystemUtils.IS_OS_LINUX) {
+                    contents = File(contents, "lib")
+                }
+            } else if (SystemUtils.IS_OS_WINDOWS) {
+                contents = contents.parentFile ?: return
+            }
 
-        val jna = FileUtils.getFile(dylib, "jna")
-        if (jna.exists()) {
-            System.setProperty("jna.nounpack", "true")
-            System.setProperty("jna.boot.library.path", jna.absolutePath)
-        }
+            val dylib = FileUtils.getFile(contents, "app", "dylib")
+            if (dylib.exists().not()) {
+                return
+            }
 
-        val pty4j = FileUtils.getFile(dylib, "pty4j")
-        if (pty4j.exists()) {
-            System.setProperty(PtyUtil.PREFERRED_NATIVE_FOLDER_KEY, pty4j.absolutePath)
-        }
+            val jna = FileUtils.getFile(dylib, "jna")
+            if (jna.exists()) {
+                System.setProperty("jna.nounpack", "true")
+                System.setProperty("jna.boot.library.path", jna.absolutePath)
+            }
 
-        val jSerialComm = FileUtils.getFile(dylib, "jSerialComm")
-        if (jSerialComm.exists()) {
-            System.setProperty("jSerialComm.library.path", jSerialComm.absolutePath)
-        }
+            val pty4j = FileUtils.getFile(dylib, "pty4j")
+            if (pty4j.exists()) {
+                System.setProperty(PtyUtil.PREFERRED_NATIVE_FOLDER_KEY, pty4j.absolutePath)
+            }
 
-        val restart4j = FileUtils.getFile(
-            dylib, "restart4j",
-            if (SystemUtils.IS_OS_WINDOWS) "restarter.exe" else "restarter"
-        )
-        if (restart4j.exists()) {
-            System.setProperty("restarter.path", restart4j.absolutePath)
-        }
+            val jSerialComm = FileUtils.getFile(dylib, "jSerialComm")
+            if (jSerialComm.exists()) {
+                System.setProperty("jSerialComm.library.path", jSerialComm.absolutePath)
+            }
 
-        val sqlite = FileUtils.getFile(dylib, "sqlite-jdbc")
-        if (sqlite.exists()) {
-            System.setProperty("org.sqlite.lib.path", sqlite.absolutePath)
-        }
+            val restart4j = FileUtils.getFile(
+                dylib, "restart4j",
+                if (SystemUtils.IS_OS_WINDOWS) "restarter.exe" else "restarter"
+            )
+            if (restart4j.exists()) {
+                System.setProperty("restarter.path", restart4j.absolutePath)
+            }
 
-        val flatlaf = FileUtils.getFile(dylib, "flatlaf")
-        if (flatlaf.exists()) {
-            System.setProperty(FlatSystemProperties.NATIVE_LIBRARY_PATH, flatlaf.absolutePath)
-        }
+            val sqlite = FileUtils.getFile(dylib, "sqlite-jdbc")
+            if (sqlite.exists()) {
+                System.setProperty("org.sqlite.lib.path", sqlite.absolutePath)
+            }
 
+            val flatlaf = FileUtils.getFile(dylib, "flatlaf")
+            if (flatlaf.exists()) {
+                System.setProperty(FlatSystemProperties.NATIVE_LIBRARY_PATH, flatlaf.absolutePath)
+            }
+
+        }
     }
 
     /**

--- a/src/main/kotlin/app/termora/cli/AssetInfo.kt
+++ b/src/main/kotlin/app/termora/cli/AssetInfo.kt
@@ -1,0 +1,19 @@
+package app.termora.cli
+
+import kotlinx.serialization.Serializable
+
+/** 暴露给外部的主机信息——绝不含任何凭证字段 */
+@Serializable
+data class AssetInfo(
+    val id: String,
+    val name: String,
+    val protocol: String,
+    val host: String,
+    val port: Int,
+    val username: String,
+    val remark: String,
+)
+
+/** assets list 的 JSON 包装：{"assets":[...]} */
+@Serializable
+data class AssetList(val assets: List<AssetInfo>)

--- a/src/main/kotlin/app/termora/cli/AssetLister.kt
+++ b/src/main/kotlin/app/termora/cli/AssetLister.kt
@@ -1,0 +1,33 @@
+package app.termora.cli
+
+import app.termora.Host
+import app.termora.cli.guard.WhitelistManager
+
+/**
+ * 列出可暴露给外部 agent 的主机。
+ * @param hostsProvider 取全部主机；生产用 HostManager.getInstance()::hosts
+ */
+class AssetLister(
+    private val hostsProvider: () -> List<Host>,
+    private val whitelist: WhitelistManager,
+) {
+    fun list(keyword: String? = null): List<AssetInfo> {
+        val kw = keyword?.trim()?.lowercase()
+        val allowed = whitelist.ids()
+        return hostsProvider()
+            .filter { !it.isFolder && !it.deleted }
+            .filter { it.id in allowed }
+            .filter { kw.isNullOrEmpty() || matches(it, kw) }
+            .map {
+                AssetInfo(
+                    id = it.id, name = it.name, protocol = it.protocol,
+                    host = it.host, port = it.port, username = it.username, remark = it.remark,
+                )
+            }
+    }
+
+    private fun matches(host: Host, kwLower: String): Boolean =
+        host.name.lowercase().contains(kwLower) ||
+            host.host.lowercase().contains(kwLower) ||
+            host.remark.lowercase().contains(kwLower)
+}

--- a/src/main/kotlin/app/termora/cli/CliBootstrap.kt
+++ b/src/main/kotlin/app/termora/cli/CliBootstrap.kt
@@ -1,0 +1,23 @@
+package app.termora.cli
+
+import app.termora.ApplicationInitializr
+import app.termora.database.DatabaseManager
+
+/** headless 初始化：不启动 GUI，仅准备数据库访问。 */
+object CliBootstrap {
+    @Volatile
+    private var initialized = false
+
+    @Synchronized
+    fun init() {
+        if (initialized) return
+        // 绝不弹窗的硬保证：任何创建 Swing 窗口的代码会抛 HeadlessException
+        System.setProperty("java.awt.headless", "true")
+        // 打包版会把 sqlite 等 native 库抽到 app/dylib，需设置系统属性才能定位（与 GUI 启动一致）。
+        // 开发版 appPath 为空，该调用内部直接 return，是 no-op。
+        ApplicationInitializr.setupNativeLibraries()
+        // 触发数据库初始化（其 init 会初始化 DatabaseSecret，自动解锁；数据库路径 baseDataDir/config/termora.db）
+        DatabaseManager.getInstance()
+        initialized = true
+    }
+}

--- a/src/main/kotlin/app/termora/cli/CliError.kt
+++ b/src/main/kotlin/app/termora/cli/CliError.kt
@@ -1,0 +1,15 @@
+package app.termora.cli
+
+/** CLI 退出码约定 */
+object ExitCodes {
+    const val OK = 0
+    const val USAGE = 1          // 参数错误
+    const val NOT_FOUND = 2      // 主机不存在
+    const val FORBIDDEN = 3      // 白名单未授权
+    const val DANGEROUS = 4      // 危险命令被拦截
+    const val CONNECT_FAIL = 5   // 连接/认证失败
+    const val DISABLED = 6       // termora-cli 总开关未启用
+}
+
+/** 携带退出码的受控错误；CLI 顶层捕获后打印 message 到 stderr 并以该码退出 */
+class CliError(val code: Int, message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/src/main/kotlin/app/termora/cli/CliMain.kt
+++ b/src/main/kotlin/app/termora/cli/CliMain.kt
@@ -1,0 +1,142 @@
+package app.termora.cli
+
+import app.termora.HostManager
+import app.termora.cli.guard.Auditor
+import app.termora.cli.guard.DangerousCommandFilter
+import app.termora.cli.guard.WhitelistManager
+import app.termora.cli.output.CliOutput
+import app.termora.database.DatabaseManager
+import kotlin.system.exitProcess
+
+private const val USAGE = """termora-cli — 通过 Termora 已保存的主机配置执行远程命令
+
+用法:
+  termora-cli exec <asset-id> "<command>"     执行远程命令
+  termora-cli exec <asset-id> --stdin          从标准输入读取命令（规避 shell 转义）
+  termora-cli assets list [-q <keyword>] [--json]   列出白名单内可访问的主机（不含凭证）
+  termora-cli upload <asset-id> <local> <remote>    上传本地文件到远程（SFTP，scp 语义）
+  termora-cli download <asset-id> <remote> <local>  从远程下载文件到本地（SFTP，scp 语义）
+  termora-cli --help
+"""
+
+fun main(args: Array<String>) {
+    if (args.isEmpty() || args[0] == "--help" || args[0] == "-h") {
+        println(USAGE)
+        exitProcess(if (args.isEmpty()) ExitCodes.USAGE else ExitCodes.OK)
+    }
+
+    try {
+        when (args[0]) {
+            "exec" -> {
+                CliBootstrap.init(); ensureEnabled()
+                runExec(args.drop(1))
+            }
+            "assets" -> {
+                CliBootstrap.init(); ensureEnabled()
+                runAssets(args.drop(1))
+            }
+            "upload" -> {
+                CliBootstrap.init(); ensureEnabled()
+                runUpload(args.drop(1))
+            }
+            "download" -> {
+                CliBootstrap.init(); ensureEnabled()
+                runDownload(args.drop(1))
+            }
+            else -> throw CliError(ExitCodes.USAGE, "未知子命令: ${args[0]}\n$USAGE")
+        }
+    } catch (e: CliError) {
+        System.err.println(e.message)
+        exitProcess(e.code)
+    }
+}
+
+private fun runExec(rest: List<String>) {
+    if (rest.isEmpty()) throw CliError(ExitCodes.USAGE, "缺少 <asset-id>\n$USAGE")
+    val assetId = rest[0]
+    val command = when {
+        rest.getOrNull(1) == "--stdin" -> System.`in`.readBytes().toString(Charsets.UTF_8)
+        rest.size >= 2 -> rest.drop(1).joinToString(" ")
+        else -> throw CliError(ExitCodes.USAGE, "缺少命令\n$USAGE")
+    }
+
+    val executor = SshExecutor(
+        hostResolver = HostManager.getInstance()::getHost,
+        whitelist = whitelistManager(),
+        dangerous = DangerousCommandFilter(),
+        auditor = Auditor(Auditor.defaultFile()),
+    )
+
+    val result = executor.execute(assetId, command)
+    val out = CliOutput.auto()
+    print(out.renderExec(result))
+    // 人类可读模式下，若 stdout 未以换行结尾则补一个换行；JSON 模式不额外加换行。
+    if (System.console() != null && !result.stdout.endsWith("\n")) println()
+    exitProcess(result.exitCode)
+}
+
+/** 从数据库 setting `cli.whitelist` 读取白名单（exec/assets/upload/download 共用）。 */
+private fun whitelistManager() = WhitelistManager {
+    DatabaseManager.getInstance().properties.getString(WhitelistManager.SETTING_KEY, "[]")
+}
+
+/**
+ * 校验 termora-cli 总开关（setting `cli.enabled`，默认 false）。
+ * 未启用时抛 [CliError]（退出码 6）。须在 [CliBootstrap.init] 之后调用（依赖数据库已初始化）。
+ */
+private fun ensureEnabled() {
+    val enabled = DatabaseManager.getInstance().properties
+        .getString(WhitelistManager.ENABLED_KEY, "false")
+        .toBooleanStrictOrNull() ?: false
+    if (!enabled) {
+        throw CliError(
+            ExitCodes.DISABLED,
+            "termora-cli 未启用。请在 Termora 设置 →「命令行工具」中开启「启用 termora-cli」后再使用。",
+        )
+    }
+}
+
+private fun runAssets(rest: List<String>) {
+    if (rest.firstOrNull() != "list") {
+        throw CliError(ExitCodes.USAGE, "用法: termora-cli assets list [-q <keyword>] [--json]")
+    }
+    var keyword: String? = null
+    val args = rest.drop(1)
+    var i = 0
+    while (i < args.size) {
+        when (args[i]) {
+            "-q" -> {
+                keyword = args.getOrNull(i + 1)
+                i += 2
+            }
+            // 其它参数（含显式 --json）一律忽略：输出模式由 CliOutput.auto() 按 TTY 决定
+            else -> i += 1
+        }
+    }
+    val lister = AssetLister(
+        hostsProvider = HostManager.getInstance()::hosts,
+        whitelist = whitelistManager(),
+    )
+    print(CliOutput.auto().renderAssets(lister.list(keyword)))
+    exitProcess(ExitCodes.OK)
+}
+
+private fun newSftpTransfer() = SftpTransfer(
+    hostResolver = HostManager.getInstance()::getHost,
+    whitelist = whitelistManager(),
+    auditor = Auditor(Auditor.defaultFile()),
+)
+
+private fun runUpload(rest: List<String>) {
+    if (rest.size < 3) throw CliError(ExitCodes.USAGE, "用法: termora-cli upload <asset-id> <local> <remote>")
+    val r = newSftpTransfer().upload(rest[0], rest[1], rest[2])
+    print(CliOutput.auto().renderTransfer(r))
+    exitProcess(if (r.ok) ExitCodes.OK else ExitCodes.CONNECT_FAIL)
+}
+
+private fun runDownload(rest: List<String>) {
+    if (rest.size < 3) throw CliError(ExitCodes.USAGE, "用法: termora-cli download <asset-id> <remote> <local>")
+    val r = newSftpTransfer().download(rest[0], rest[1], rest[2])
+    print(CliOutput.auto().renderTransfer(r))
+    exitProcess(if (r.ok) ExitCodes.OK else ExitCodes.CONNECT_FAIL)
+}

--- a/src/main/kotlin/app/termora/cli/ExecResult.kt
+++ b/src/main/kotlin/app/termora/cli/ExecResult.kt
@@ -1,0 +1,13 @@
+package app.termora.cli
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ExecResult(
+    val exitCode: Int,
+    val stdout: String,
+    val stderr: String,
+    val host: String,
+    // 总耗时（建连 + 执行）由 SshExecutor.execute 统一填入；默认 0 仅作占位。
+    val durationMs: Long = 0,
+)

--- a/src/main/kotlin/app/termora/cli/SftpTransfer.kt
+++ b/src/main/kotlin/app/termora/cli/SftpTransfer.kt
@@ -1,0 +1,80 @@
+package app.termora.cli
+
+import app.termora.Host
+import app.termora.cli.guard.Auditor
+import app.termora.cli.guard.WhitelistManager
+import app.termora.plugin.internal.ssh.SshClients
+import org.apache.commons.io.IOUtils
+import org.apache.sshd.sftp.client.impl.DefaultSftpClientFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * SFTP 文件传输：白名单校验 → openClient/openSession → SFTP → Files.copy（scp 语义）→ 审计。
+ * 单文件传输；文件夹递归属后续增强。失败统一转 CliError。
+ *
+ * @param hostResolver 生产用 HostManager.getInstance()::getHost
+ */
+class SftpTransfer(
+    private val hostResolver: (String) -> Host?,
+    private val whitelist: WhitelistManager,
+    private val auditor: Auditor,
+) {
+    fun upload(assetId: String, localPath: String, remotePath: String): TransferResult =
+        run(assetId, "upload", localPath, remotePath) { fs, host ->
+            val src = Path.of(localPath)
+            val dst = resolveScpTarget(fs.getPath(remotePath), src.fileName.toString())
+            Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING)
+            TransferResult(ok = true, bytes = Files.size(dst), host = host.name)
+        }
+
+    fun download(assetId: String, remotePath: String, localPath: String): TransferResult =
+        run(assetId, "download", remotePath, localPath) { fs, host ->
+            val src = fs.getPath(remotePath)
+            val dst = resolveScpTarget(Path.of(localPath), src.fileName.toString())
+            Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING)
+            TransferResult(ok = true, bytes = Files.size(dst), host = host.name)
+        }
+
+    /** scp 语义：目标已存在且是目录 → 源保留原名放入；否则目标路径即最终路径。 */
+    private fun resolveScpTarget(target: Path, sourceName: String): Path =
+        if (Files.isDirectory(target)) target.resolve(sourceName) else target
+
+    private fun run(
+        assetId: String, action: String, from: String, to: String,
+        block: (java.nio.file.FileSystem, Host) -> TransferResult,
+    ): TransferResult {
+        val host = hostResolver(assetId) ?: throw CliError(ExitCodes.NOT_FOUND, "主机不存在: $assetId")
+        if (!whitelist.isAllowed(assetId)) {
+            auditor.record(
+                assetId = assetId, host = host.host, action = action,
+                command = "$action $from -> $to", exitCode = ExitCodes.FORBIDDEN,
+            )
+            throw CliError(ExitCodes.FORBIDDEN, "主机未授权 AI 访问（不在白名单）: ${host.name}")
+        }
+        try {
+            val client = SshClients.openClient(host)
+            try {
+                val session = SshClients.openSession(host, client)
+                val fs = DefaultSftpClientFactory.INSTANCE.createSftpFileSystem(session)
+                val result = fs.use { block(it, host) }
+                auditor.record(
+                    assetId = assetId, host = host.host, action = action,
+                    command = "$action $from -> $to", exitCode = 0,
+                )
+                return result
+            } finally {
+                IOUtils.closeQuietly(client)
+            }
+        } catch (e: CliError) {
+            throw e
+        } catch (e: Exception) {
+            auditor.record(
+                assetId = assetId, host = host.host, action = action,
+                command = "$action $from -> $to", exitCode = ExitCodes.CONNECT_FAIL,
+            )
+            throw CliError(ExitCodes.CONNECT_FAIL, "$action 失败: ${e.message}", e)
+        }
+    }
+}

--- a/src/main/kotlin/app/termora/cli/SshExecutor.kt
+++ b/src/main/kotlin/app/termora/cli/SshExecutor.kt
@@ -1,0 +1,90 @@
+package app.termora.cli
+
+import app.termora.Host
+import app.termora.cli.guard.Auditor
+import app.termora.cli.guard.DangerousCommandFilter
+import app.termora.cli.guard.WhitelistManager
+import app.termora.plugin.internal.ssh.SshClients
+import org.apache.commons.io.IOUtils
+import org.apache.sshd.client.channel.ClientChannelEvent
+import org.apache.sshd.client.session.ClientSession
+import java.io.ByteArrayOutputStream
+import java.time.Duration
+import java.util.EnumSet
+
+/**
+ * 组合护栏 + SSH exec：白名单 → 危险命令拦截 → openClient/openSession → exec（收 stdout+stderr+exitCode）→ 审计。
+ * 全程不弹 GUI（用不带 Window 的 openClient）；任何失败转 CliError。
+ *
+ * @param hostResolver 按 id 取 Host；生产用 HostManager.getInstance()::getHost
+ * @param timeout 仅作用于命令**执行阶段**（exec channel 的 open/waitFor）；建连与认证阶段的超时
+ *                由目标主机的 `host.options.extras["timeout"]`（默认 60s）控制，不受此参数约束。
+ */
+class SshExecutor(
+    private val hostResolver: (String) -> Host?,
+    private val whitelist: WhitelistManager,
+    private val dangerous: DangerousCommandFilter,
+    private val auditor: Auditor,
+    private val timeout: Duration = Duration.ofSeconds(60),
+) {
+    fun execute(assetId: String, command: String): ExecResult {
+        val host = hostResolver(assetId)
+            ?: throw CliError(ExitCodes.NOT_FOUND, "主机不存在: $assetId")
+
+        if (!whitelist.isAllowed(assetId)) {
+            auditor.record(assetId = assetId, host = host.host, command = command, exitCode = ExitCodes.FORBIDDEN)
+            throw CliError(ExitCodes.FORBIDDEN, "主机未授权 AI 访问（不在白名单）: ${host.name}")
+        }
+
+        dangerous.match(command)?.let { rule ->
+            auditor.record(assetId = assetId, host = host.host, command = command, exitCode = ExitCodes.DANGEROUS)
+            throw CliError(ExitCodes.DANGEROUS, "危险命令被拦截（规则 $rule）: $command")
+        }
+
+        val t0 = System.currentTimeMillis()
+        val result = try {
+            val client = SshClients.openClient(host)
+            try {
+                val session = SshClients.openSession(host, client)
+                exec(session, command, host.name)
+            } finally {
+                IOUtils.closeQuietly(client)
+            }
+        } catch (e: CliError) {
+            throw e
+        } catch (e: Exception) {
+            auditor.record(assetId = assetId, host = host.host, command = command, exitCode = ExitCodes.CONNECT_FAIL)
+            throw CliError(ExitCodes.CONNECT_FAIL, "连接或执行失败: ${e.message}", e)
+        }
+
+        auditor.record(assetId = assetId, host = host.host, command = command, exitCode = result.exitCode)
+        // 总耗时（建连 + 执行），由 execute 统一计时。
+        return result.copy(durationMs = System.currentTimeMillis() - t0)
+    }
+
+    /** 自带的 exec：复用 SshClients.execChannel(:135) 的逻辑，额外收 stderr。耗时由调用方 [execute] 统一计。 */
+    private fun exec(
+        session: ClientSession,
+        command: String,
+        hostName: String,
+    ): ExecResult {
+        val bout = ByteArrayOutputStream()
+        val berr = ByteArrayOutputStream()
+        val channel = session.createExecChannel(command)
+        channel.out = bout
+        channel.err = berr
+        if (channel.open().verify(timeout).await(timeout)) {
+            channel.waitFor(EnumSet.of(ClientChannelEvent.CLOSED), timeout)
+        }
+        // exitCode = -1 表示未能取得远端退出状态（如通道异常关闭/未回 exit-status），
+        // 并非命令真实返回 -1；调用方据此判断成败时需注意。
+        val exit = channel.exitStatus ?: -1
+        IOUtils.closeQuietly(channel)
+        return ExecResult(
+            exitCode = exit,
+            stdout = bout.toString(Charsets.UTF_8),
+            stderr = berr.toString(Charsets.UTF_8),
+            host = hostName,
+        )
+    }
+}

--- a/src/main/kotlin/app/termora/cli/TransferResult.kt
+++ b/src/main/kotlin/app/termora/cli/TransferResult.kt
@@ -1,0 +1,6 @@
+package app.termora.cli
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TransferResult(val ok: Boolean, val bytes: Long, val host: String)

--- a/src/main/kotlin/app/termora/cli/guard/Auditor.kt
+++ b/src/main/kotlin/app/termora/cli/guard/Auditor.kt
@@ -1,0 +1,32 @@
+package app.termora.cli.guard
+
+import app.termora.Application
+import app.termora.Application.ohMyJson
+import kotlinx.serialization.Serializable
+import java.io.File
+
+/** 审计：每条操作追加一行 JSON 到文件。用独立文件而非数据库，规避 SQLite 写锁与 EDT 写检查。 */
+class Auditor(private val file: File) {
+
+    @Serializable
+    data class Entry(
+        val time: Long,
+        val assetId: String,
+        val host: String,
+        val action: String,
+        val command: String,
+        val exitCode: Int,
+    )
+
+    @Synchronized
+    fun record(assetId: String, host: String, action: String = "exec", command: String, exitCode: Int) {
+        val entry = Entry(System.currentTimeMillis(), assetId, host, action, command, exitCode)
+        file.parentFile?.mkdirs()
+        file.appendText(ohMyJson.encodeToString(Entry.serializer(), entry) + "\n")
+    }
+
+    companion object {
+        /** 生产路径：<baseDataDir>/cli-audit.log */
+        fun defaultFile(): File = File(Application.getBaseDataDir(), "cli-audit.log")
+    }
+}

--- a/src/main/kotlin/app/termora/cli/guard/DangerousCommandFilter.kt
+++ b/src/main/kotlin/app/termora/cli/guard/DangerousCommandFilter.kt
@@ -1,0 +1,37 @@
+package app.termora.cli.guard
+
+/**
+ * 危险命令拦截。命令字符串层面的保守匹配，目的是降低误操作风险，并非完整安全沙箱。
+ * match 返回命中的规则名；未命中返回 null。
+ */
+class DangerousCommandFilter(
+    private val rules: List<Rule> = DEFAULT_RULES,
+) {
+    data class Rule(val name: String, val regex: Regex)
+
+    fun match(command: String): String? {
+        val c = command.trim()
+        return rules.firstOrNull { it.regex.containsMatchIn(c) }?.name
+    }
+
+    companion object {
+        // RegexOption.IGNORE_CASE 统一忽略大小写
+        private fun r(name: String, pattern: String) =
+            Rule(name, Regex(pattern, RegexOption.IGNORE_CASE))
+
+        val DEFAULT_RULES: List<Rule> = listOf(
+            // rm -rf / 或 /* 或 ~（中间允许任意空白与 sudo 前缀）
+            // 标志段用前瞻同时要求含 r 与 f，兼容 -rf/-fr/-Rf/-rfv 等任意顺序与附加标志
+            r("rm-rf-root", """\brm\s+(-[a-zA-Z]*\s+)*-(?=[a-zA-Z]*r)(?=[a-zA-Z]*f)[a-zA-Z]+\s+(/|/\*|~)(\s|$)"""),
+            r("mkfs", """\bmkfs(\.\w+)?\b"""),
+            r("dd-to-device", """\bdd\b.*\bof=/dev/"""),
+            r("redirect-to-device", """>\s*/dev/sd"""),
+            // 关机/重启类关键字锚定到命令位置（行首、sudo 之后，或 ;/&/| 等命令分隔符之后），
+            // 不把普通空白当作命令边界，避免 cat halt.txt / echo reboot now 之类子串误报
+            r("shutdown", """(?:^|[;|&]\s*|\bsudo\s+)(shutdown|reboot|halt|poweroff|init\s+0)\b"""),
+            r("fork-bomb", """:\(\)\s*\{.*:\|:.*&.*\}\s*;\s*:"""),
+            r("chmod-root", """\bchmod\s+-R\s+777\s+/(\s|$)"""),
+            r("chown-root", """\bchown\s+-R\s+\S+\s+/(\s|$)"""),
+        )
+    }
+}

--- a/src/main/kotlin/app/termora/cli/guard/WhitelistManager.kt
+++ b/src/main/kotlin/app/termora/cli/guard/WhitelistManager.kt
@@ -1,0 +1,28 @@
+package app.termora.cli.guard
+
+import app.termora.Application.ohMyJson
+
+/**
+ * 主机白名单（只读）。白名单是 host id 列表，存于数据库 setting `cli.whitelist`（JSON 数组）。
+ * @param reader 返回 cli.whitelist 的原始 JSON 字符串
+ */
+class WhitelistManager(
+    private val reader: () -> String,
+) {
+    fun isAllowed(hostId: String): Boolean = ids().contains(hostId)
+
+    fun ids(): Set<String> {
+        val raw = reader().trim()
+        if (raw.isEmpty()) return emptySet()
+        return runCatching {
+            ohMyJson.decodeFromString<List<String>>(raw).toSet()
+        }.getOrDefault(emptySet())
+    }
+
+    companion object {
+        const val SETTING_KEY = "cli.whitelist"
+
+        /** termora-cli 总开关 setting key（默认 false） */
+        const val ENABLED_KEY = "cli.enabled"
+    }
+}

--- a/src/main/kotlin/app/termora/cli/output/CliOutput.kt
+++ b/src/main/kotlin/app/termora/cli/output/CliOutput.kt
@@ -1,0 +1,43 @@
+package app.termora.cli.output
+
+import app.termora.Application.ohMyJson
+import app.termora.cli.AssetInfo
+import app.termora.cli.AssetList
+import app.termora.cli.ExecResult
+import app.termora.cli.TransferResult
+
+/**
+ * @param json true 输出 JSON（被管道/agent 调用时）；false 输出人类可读（交互终端）。
+ * 生产构造默认 `json = System.console() == null`。
+ */
+class CliOutput(private val json: Boolean) {
+
+    fun renderExec(result: ExecResult): String {
+        if (json) return ohMyJson.encodeToString(ExecResult.serializer(), result)
+        return buildString {
+            if (result.stdout.isNotEmpty()) append(result.stdout)
+            if (result.stderr.isNotEmpty()) {
+                if (isNotEmpty() && !endsWith("\n")) append('\n')
+                append(result.stderr)
+            }
+        }
+    }
+
+    fun renderAssets(assets: List<AssetInfo>): String {
+        if (json) return ohMyJson.encodeToString(AssetList.serializer(), AssetList(assets))
+        if (assets.isEmpty()) return "（白名单为空，没有可访问的主机）\n"
+        return assets.joinToString("\n", postfix = "\n") {
+            "${it.id}  ${it.name}  ${it.username}@${it.host}:${it.port}  [${it.protocol}]" +
+                if (it.remark.isNotBlank()) "  ${it.remark}" else ""
+        }
+    }
+
+    fun renderTransfer(result: TransferResult): String {
+        if (json) return ohMyJson.encodeToString(TransferResult.serializer(), result)
+        return "ok=${result.ok} bytes=${result.bytes} host=${result.host}\n"
+    }
+
+    companion object {
+        fun auto(): CliOutput = CliOutput(json = System.console() == null)
+    }
+}

--- a/src/main/kotlin/app/termora/plugin/PluginManager.kt
+++ b/src/main/kotlin/app/termora/plugin/PluginManager.kt
@@ -5,6 +5,7 @@ import app.termora.ApplicationScope
 import app.termora.FramePlugin
 import app.termora.account.AccountPlugin
 import app.termora.plugin.internal.badge.BadgePlugin
+import app.termora.plugin.internal.cli.CliInternalPlugin
 import app.termora.plugin.internal.extension.DynamicExtensionPlugin
 import app.termora.plugin.internal.local.LocalInternalPlugin
 import app.termora.plugin.internal.plugin.PluginInternalPlugin
@@ -137,6 +138,8 @@ internal class PluginManager private constructor() {
 
         // floating
         plugins.add(PluginDescriptor(FloatingToolbarPlugin(), origin = PluginOrigin.Internal, version = version))
+        // cli plugin
+        plugins.add(PluginDescriptor(CliInternalPlugin(), origin = PluginOrigin.Internal, version = version))
     }
 
     private fun loadSystemPlugins() {

--- a/src/main/kotlin/app/termora/plugin/internal/cli/CliInternalPlugin.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/cli/CliInternalPlugin.kt
@@ -1,0 +1,17 @@
+package app.termora.plugin.internal.cli
+
+import app.termora.SettingsOptionExtension
+import app.termora.plugin.Extension
+import app.termora.plugin.InternalPlugin
+
+internal class CliInternalPlugin : InternalPlugin() {
+    init {
+        support.addExtension(SettingsOptionExtension::class.java) { CliSettingsOptionExtension.instance }
+    }
+
+    override fun getName(): String = "CLI"
+
+    override fun <T : Extension> getExtensions(clazz: Class<T>): List<T> {
+        return support.getExtensions(clazz)
+    }
+}

--- a/src/main/kotlin/app/termora/plugin/internal/cli/CliSettingsOptionExtension.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/cli/CliSettingsOptionExtension.kt
@@ -1,0 +1,12 @@
+package app.termora.plugin.internal.cli
+
+import app.termora.OptionsPane
+import app.termora.SettingsOptionExtension
+
+class CliSettingsOptionExtension private constructor() : SettingsOptionExtension {
+    companion object {
+        val instance = CliSettingsOptionExtension()
+    }
+
+    override fun createSettingsOption(): OptionsPane.Option = CliWhitelistOption()
+}

--- a/src/main/kotlin/app/termora/plugin/internal/cli/CliWhitelistOption.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/cli/CliWhitelistOption.kt
@@ -1,0 +1,303 @@
+package app.termora.plugin.internal.cli
+
+import app.termora.Host
+import app.termora.HostManager
+import app.termora.I18n
+import app.termora.Icons
+import app.termora.OptionsPane
+import app.termora.cli.guard.WhitelistManager
+import app.termora.database.DatabaseManager
+import app.termora.protocol.ProtocolProvider
+import com.formdev.flatlaf.icons.FlatTreeClosedIcon
+import com.formdev.flatlaf.icons.FlatTreeOpenIcon
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.FlowLayout
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.io.File
+import javax.swing.BoxLayout
+import javax.swing.Icon
+import javax.swing.JButton
+import javax.swing.JCheckBox
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JOptionPane
+import javax.swing.JPanel
+import javax.swing.JScrollPane
+import javax.swing.JTree
+import javax.swing.SwingUtilities
+import javax.swing.UIManager
+import javax.swing.border.EmptyBorder
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.TreeCellRenderer
+
+/**
+ * 设置页「命令行工具」：树形分组展示主机，勾选哪些允许被 AI（termora-cli）访问，实时写入 cli.whitelist。
+ */
+class CliWhitelistOption : JPanel(BorderLayout()), OptionsPane.Option {
+
+    private val store = WhitelistStore(
+        read = { DatabaseManager.getInstance().properties.getString(WhitelistStore.SETTING_KEY, "[]") },
+        write = { DatabaseManager.getInstance().properties.putString(WhitelistStore.SETTING_KEY, it) },
+    )
+
+    private val properties get() = DatabaseManager.getInstance().properties
+
+    /** termora-cli 总开关复选框；始终可点（不随自身禁用），切换时联动启停 [controls]。 */
+    private val enableCheckBox = JCheckBox(I18n.getString("termora.settings.cli.enable"))
+
+    /** 需随总开关启停的控件（白名单树、滚动面板、skill/path 按钮、tip 等）；开关本身不在其中。 */
+    private val controls = mutableListOf<JComponent>()
+
+    /** 白名单快照（host id 集合）；渲染器据此判断勾选状态，避免每行重绘都解析一次 JSON。 */
+    private var enabledSnapshot: Set<String> = emptySet()
+
+    init {
+        initView()
+    }
+
+    private fun initView() {
+        // termora-cli 总开关（north 区最顶部，tip 之上）；默认关闭，切换时写 cli.enabled 并联动启停其它控件
+        enableCheckBox.isSelected =
+            properties.getString(WhitelistManager.ENABLED_KEY, "false").toBooleanStrictOrNull() ?: false
+        enableCheckBox.toolTipText = I18n.getString("termora.settings.cli.enable.tip")
+        enableCheckBox.border = EmptyBorder(8, 8, 0, 8)
+        enableCheckBox.addActionListener {
+            properties.putString(WhitelistManager.ENABLED_KEY, enableCheckBox.isSelected.toString())
+            setControlsEnabled(enableCheckBox.isSelected)
+        }
+
+        val tip = JLabel(I18n.getString("termora.settings.cli.whitelist.tip"))
+        tip.border = EmptyBorder(8, 8, 4, 8)
+        controls.add(tip)
+
+        // skill 按钮行
+        val skillToolbar = JPanel(FlowLayout(FlowLayout.LEFT, 6, 0))
+        skillToolbar.border = EmptyBorder(0, 6, 0, 8)
+        val copyButton = JButton(I18n.getString("termora.settings.cli.skill.copy"))
+        val claudeButton = JButton(I18n.getString("termora.settings.cli.skill.install.claude"))
+        val codexButton = JButton(I18n.getString("termora.settings.cli.skill.install.codex"))
+        copyButton.addActionListener { copySkillToClipboard() }
+        claudeButton.addActionListener { installSkill(SkillInstaller.claudeBaseDir()) }
+        codexButton.addActionListener { installSkill(SkillInstaller.codexBaseDir()) }
+        skillToolbar.add(copyButton)
+        skillToolbar.add(claudeButton)
+        skillToolbar.add(codexButton)
+        controls.add(copyButton)
+        controls.add(claudeButton)
+        controls.add(codexButton)
+
+        // PATH 按钮行（按钮变多，分两行布局确保都可见）
+        val pathToolbar = JPanel(FlowLayout(FlowLayout.LEFT, 6, 0))
+        pathToolbar.border = EmptyBorder(0, 6, 4, 8)
+        val addPathButton = JButton(I18n.getString("termora.settings.cli.path.add"))
+        val removePathButton = JButton(I18n.getString("termora.settings.cli.path.remove"))
+        addPathButton.addActionListener { addToPath() }
+        removePathButton.addActionListener { removeFromPath() }
+        pathToolbar.add(addPathButton)
+        pathToolbar.add(removePathButton)
+        controls.add(addPathButton)
+        controls.add(removePathButton)
+
+        // 两行按钮栏（skill + path）纵向排列
+        val toolbar = JPanel()
+        toolbar.layout = BoxLayout(toolbar, BoxLayout.Y_AXIS)
+        skillToolbar.alignmentX = LEFT_ALIGNMENT
+        pathToolbar.alignmentX = LEFT_ALIGNMENT
+        toolbar.add(skillToolbar)
+        toolbar.add(pathToolbar)
+
+        // north 区（开关 + tip + 按钮栏）在空主机早退判断之前就 add，确保无主机时开关与按钮依然可见
+        val north = JPanel(BorderLayout())
+        val northTop = JPanel(BorderLayout())
+        northTop.add(enableCheckBox, BorderLayout.NORTH)   // 开关在最顶部
+        northTop.add(tip, BorderLayout.SOUTH)
+        north.add(northTop, BorderLayout.NORTH)
+        north.add(toolbar, BorderLayout.SOUTH)
+        add(north, BorderLayout.NORTH)
+
+        val hosts = HostManager.getInstance().hosts()
+        val hasHost = hosts.any { !it.isFolder && !it.deleted }
+        if (!hasHost) {
+            val empty = JLabel(I18n.getString("termora.settings.cli.whitelist.empty"))
+            empty.border = EmptyBorder(8, 8, 8, 8)
+            add(empty, BorderLayout.CENTER)
+            controls.add(empty)
+            setControlsEnabled(enableCheckBox.isSelected)
+            return
+        }
+
+        val root = HostTreeBuilder.build(hosts)
+        val tree = JTree(root)
+        tree.isRootVisible = false
+        tree.showsRootHandles = true
+        tree.cellRenderer = WhitelistTreeCellRenderer()
+        tree.isOpaque = true
+        // 初始化白名单快照供渲染器使用
+        enabledSnapshot = store.ids()
+        // 默认展开全部
+        var i = 0
+        while (i < tree.rowCount) { tree.expandRow(i); i++ }
+
+        tree.addMouseListener(object : MouseAdapter() {
+            override fun mousePressed(e: MouseEvent) {
+                val path = tree.getPathForLocation(e.x, e.y) ?: return
+                val node = path.lastPathComponent as? DefaultMutableTreeNode ?: return
+                val host = node.userObject as? Host ?: return
+                if (host.isFolder) {
+                    if (tree.isExpanded(path)) tree.collapsePath(path) else tree.expandPath(path)
+                } else {
+                    if (!host.protocol.equals("SSH", ignoreCase = true)) return   // 非 SSH 不可勾选
+                    store.setEnabled(host.id, !store.isEnabled(host.id))
+                    enabledSnapshot = store.ids()   // 写入后刷新快照，供渲染器读取
+                    tree.repaint()
+                }
+            }
+        })
+
+        val scrollPane = JScrollPane(tree)
+        add(scrollPane, BorderLayout.CENTER)
+        // 收集联动控件：JTree 在 JScrollPane 内时，须对 tree 本身禁用才能阻止其选择/点击交互
+        controls.add(scrollPane)
+        controls.add(tree)
+
+        // 末尾按当前开关状态初始化控件可用性
+        setControlsEnabled(enableCheckBox.isSelected)
+    }
+
+    /** 根据总开关状态启停所有联动控件（开关复选框本身不受影响）。 */
+    private fun setControlsEnabled(enabled: Boolean) {
+        for (c in controls) c.isEnabled = enabled
+    }
+
+    override fun getIcon(isSelected: Boolean): Icon = Icons.terminal
+    override fun getTitle(): String = I18n.getString("termora.settings.cli")
+    override fun getJComponent(): JComponent = this
+
+    private fun copySkillToClipboard() {
+        try {
+            val selection = StringSelection(SkillInstaller.readSkill())
+            Toolkit.getDefaultToolkit().systemClipboard.setContents(selection, null)
+            JOptionPane.showMessageDialog(
+                SwingUtilities.getWindowAncestor(this),
+                I18n.getString("termora.settings.cli.skill.copied"),
+            )
+        } catch (e: Exception) {
+            JOptionPane.showMessageDialog(
+                SwingUtilities.getWindowAncestor(this),
+                I18n.getString("termora.settings.cli.skill.failed", e.message ?: e.javaClass.simpleName),
+                null, JOptionPane.ERROR_MESSAGE,
+            )
+        }
+    }
+
+    private fun installSkill(baseDir: File) {
+        try {
+            val file = SkillInstaller.installTo(baseDir)
+            JOptionPane.showMessageDialog(
+                SwingUtilities.getWindowAncestor(this),
+                I18n.getString("termora.settings.cli.skill.installed", file.absolutePath),
+            )
+        } catch (e: Exception) {
+            JOptionPane.showMessageDialog(
+                SwingUtilities.getWindowAncestor(this),
+                I18n.getString("termora.settings.cli.skill.failed", e.message ?: e.javaClass.simpleName),
+                null, JOptionPane.ERROR_MESSAGE,
+            )
+        }
+    }
+
+    private fun addToPath() {
+        try {
+            val location = PathInstaller.install()
+            val msg = buildString {
+                append(I18n.getString("termora.settings.cli.path.added", location))
+                if (PathInstaller.isPortable()) {
+                    append("\n\n").append(I18n.getString("termora.settings.cli.path.portable-note"))
+                }
+                if (PathInstaller.isDev()) {
+                    append("\n\n").append(I18n.getString("termora.settings.cli.path.dev-note"))
+                }
+            }
+            JOptionPane.showMessageDialog(SwingUtilities.getWindowAncestor(this), msg)
+        } catch (e: Exception) {
+            JOptionPane.showMessageDialog(
+                SwingUtilities.getWindowAncestor(this),
+                I18n.getString("termora.settings.cli.path.failed", e.message ?: e.javaClass.simpleName),
+                null, JOptionPane.ERROR_MESSAGE,
+            )
+        }
+    }
+
+    private fun removeFromPath() {
+        try {
+            PathInstaller.uninstall()
+            JOptionPane.showMessageDialog(
+                SwingUtilities.getWindowAncestor(this),
+                I18n.getString("termora.settings.cli.path.removed"),
+            )
+        } catch (e: Exception) {
+            JOptionPane.showMessageDialog(
+                SwingUtilities.getWindowAncestor(this),
+                I18n.getString("termora.settings.cli.path.failed", e.message ?: e.javaClass.simpleName),
+                null, JOptionPane.ERROR_MESSAGE,
+            )
+        }
+    }
+
+    private inner class WhitelistTreeCellRenderer : TreeCellRenderer {
+        private val panel = JPanel(FlowLayout(FlowLayout.LEFT, 2, 0))
+        private val checkBox = JCheckBox()
+        private val label = JLabel()
+
+        init {
+            panel.isOpaque = true
+            checkBox.isOpaque = false
+            label.isOpaque = false
+            panel.add(checkBox)
+            panel.add(label)
+        }
+
+        override fun getTreeCellRendererComponent(
+            tree: JTree, value: Any?, selected: Boolean, expanded: Boolean,
+            leaf: Boolean, row: Int, hasFocus: Boolean,
+        ): Component {
+            val node = value as? DefaultMutableTreeNode
+            val host = node?.userObject as? Host
+
+            if (selected) {
+                panel.background = UIManager.getColor("Tree.selectionBackground")
+                label.foreground = UIManager.getColor("Tree.selectionForeground")
+            } else {
+                panel.background = UIManager.getColor("Tree.background")
+                label.foreground = UIManager.getColor("Tree.foreground")
+            }
+
+            if (host == null || host.isFolder) {
+                checkBox.isVisible = false
+                label.icon = if (expanded) FlatTreeOpenIcon() else FlatTreeClosedIcon()
+                label.text = host?.name ?: ""
+            } else {
+                val isSsh = host.protocol.equals("SSH", ignoreCase = true)
+                checkBox.isVisible = true
+                checkBox.isEnabled = isSsh
+                checkBox.isSelected = isSsh && host.id in enabledSnapshot
+                checkBox.background = panel.background
+                label.isEnabled = isSsh
+                label.icon = hostIcon(host)
+                label.text = buildString {
+                    append(host.name)
+                    if (host.host.isNotBlank()) append("  ${host.username}@${host.host}:${host.port}")
+                    if (!isSsh) append("  (${I18n.getString("termora.settings.cli.whitelist.ssh-only")})")
+                }
+            }
+            return panel
+        }
+
+        private fun hostIcon(host: Host): Icon =
+            runCatching { ProtocolProvider.valueOf(host.protocol)?.getIcon() }.getOrNull() ?: Icons.terminal
+    }
+}

--- a/src/main/kotlin/app/termora/plugin/internal/cli/HostTreeBuilder.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/cli/HostTreeBuilder.kt
@@ -1,0 +1,30 @@
+package app.termora.plugin.internal.cli
+
+import app.termora.Host
+import javax.swing.tree.DefaultMutableTreeNode
+
+/**
+ * 把扁平的 List<Host> 按 parentId 构建成树。
+ * - 过滤 deleted
+ * - 同层：文件夹优先，再按 sort 升序
+ * - parentId 为 "0"/空 或指向不存在的父：挂到 root
+ * 返回一个不含 userObject 的虚拟 root，其子节点为顶层文件夹/主机；每个真实节点的 userObject 是 Host。
+ */
+object HostTreeBuilder {
+    fun build(hosts: List<Host>): DefaultMutableTreeNode {
+        val visible = hosts.filter { !it.deleted }
+        val nodes = visible.associate { it.id to DefaultMutableTreeNode(it) }
+        val root = DefaultMutableTreeNode()
+
+        val ordered = visible.sortedWith(
+            compareBy<Host> { if (it.isFolder) 0 else 1 }.thenBy { it.sort }.thenBy { it.name }
+        )
+        for (host in ordered) {
+            val node = nodes.getValue(host.id)
+            val parent = if (host.parentId == "0" || host.parentId.isBlank()) root
+            else nodes[host.parentId] ?: root
+            parent.add(node)
+        }
+        return root
+    }
+}

--- a/src/main/kotlin/app/termora/plugin/internal/cli/PathInstaller.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/cli/PathInstaller.kt
@@ -1,0 +1,130 @@
+package app.termora.plugin.internal.cli
+
+import app.termora.Application
+import app.termora.AppLayout
+import com.formdev.flatlaf.util.SystemInfo
+import com.sun.jna.platform.win32.Advapi32Util
+import com.sun.jna.platform.win32.WinReg
+import org.apache.commons.lang3.SystemUtils
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+
+/**
+ * 把 termora-cli 安装进用户 PATH。
+ * 生成 wrapper（用当前运行的 java.home 与 classpath 跑 CliMainKt），放 <baseDataDir>/bin，
+ * 再加入用户 PATH：Windows 写注册表 HKCU\Environment\Path（REG_EXPAND_SZ，去重）；
+ * macOS/Linux 软链到 ~/.local/bin。不广播 WM_SETTINGCHANGE（新终端从注册表读最新 PATH 即可）。
+ */
+object PathInstaller {
+    const val CLI_NAME = "termora-cli"
+    private const val MAIN_CLASS = "app.termora.cli.CliMainKt"
+
+    /** 开发版（./gradlew :run）下 appPath 为空；wrapper 用当前 classpath，重新构建后可能失效 */
+    fun isDev(): Boolean = Application.getAppPath().isBlank()
+
+    /** Windows Zip 便携/绿色版：移动文件夹或换盘符后，wrapper 内写死的绝对路径与系统 PATH 项都会失效 */
+    fun isPortable(): Boolean = SystemInfo.isWindows && Application.getLayout() == AppLayout.Zip
+
+    fun binDir(): File = File(Application.getBaseDataDir(), "bin")
+
+    /**
+     * 定位 jpackage 产出的 termora-cli 可执行（与主程序 launcher 同目录）。
+     * 安装版才有；开发版（appPath 空）返回 null。
+     */
+    fun packagedLauncher(): File? {
+        val appPath = Application.getAppPath()
+        if (appPath.isBlank()) return null
+        val dir = File(appPath).parentFile ?: return null
+        val name = if (SystemInfo.isWindows) "$CLI_NAME.exe" else CLI_NAME
+        val launcher = File(dir, name)
+        return if (launcher.isFile) launcher else null
+    }
+
+    /** 生成 wrapper 到 dir，返回 wrapper 文件 */
+    fun generateWrapper(dir: File): File {
+        dir.mkdirs()
+        val javaHome = System.getProperty("java.home")
+        val classpath = System.getProperty("java.class.path")
+        return if (SystemInfo.isWindows) {
+            val javaExe = File(javaHome, "bin\\java.exe").absolutePath
+            val f = File(dir, "$CLI_NAME.cmd")
+            f.writeText("@echo off\r\n\"$javaExe\" -cp \"$classpath\" $MAIN_CLASS %*\r\n", Charsets.UTF_8)
+            f
+        } else {
+            val javaExe = File(javaHome, "bin/java").absolutePath
+            val f = File(dir, CLI_NAME)
+            f.writeText("#!/bin/sh\nexec \"$javaExe\" -cp \"$classpath\" $MAIN_CLASS \"\$@\"\n", Charsets.UTF_8)
+            runCatching {
+                Files.setPosixFilePermissions(
+                    f.toPath(),
+                    setOf(
+                        PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
+                        PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
+                        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE,
+                    )
+                )
+            }
+            f
+        }
+    }
+
+    /** 安装到 PATH，返回提示给用户的目标位置描述 */
+    fun install(): String {
+        val launcher = packagedLauncher()
+        // 安装版：直接用官方 launcher 所在目录，无需自生成 wrapper
+        val target = launcher ?: generateWrapper(binDir())
+        return if (SystemInfo.isWindows) {
+            addToWindowsUserPath(target.parentFile.absolutePath)
+            target.parentFile.absolutePath
+        } else {
+            symlinkToLocalBin(target).absolutePath
+        }
+    }
+
+    /** 从 PATH 移除（对称回退） */
+    fun uninstall() {
+        if (SystemInfo.isWindows) {
+            removeFromWindowsUserPath(binDir().absolutePath)
+        } else {
+            val link = File(SystemUtils.getUserHome(), ".local/bin/$CLI_NAME")
+            runCatching { Files.deleteIfExists(link.toPath()) }
+        }
+    }
+
+    // ---- Windows ----
+    private fun readUserPath(): String {
+        return runCatching {
+            if (Advapi32Util.registryValueExists(WinReg.HKEY_CURRENT_USER, "Environment", "Path"))
+                Advapi32Util.registryGetStringValue(WinReg.HKEY_CURRENT_USER, "Environment", "Path")
+            else ""
+        }.getOrDefault("")
+    }
+
+    private fun addToWindowsUserPath(dir: String) {
+        val parts = readUserPath().split(";").filter { it.isNotBlank() }
+        if (parts.any { it.equals(dir, ignoreCase = true) }) return // 已存在，去重
+        val newPath = (parts + dir).joinToString(";")
+        Advapi32Util.registrySetExpandableStringValue(WinReg.HKEY_CURRENT_USER, "Environment", "Path", newPath)
+    }
+
+    private fun removeFromWindowsUserPath(dir: String) {
+        val parts = readUserPath().split(";").filter { it.isNotBlank() && !it.equals(dir, ignoreCase = true) }
+        Advapi32Util.registrySetExpandableStringValue(WinReg.HKEY_CURRENT_USER, "Environment", "Path", parts.joinToString(";"))
+    }
+
+    // ---- macOS / Linux ----
+    private fun symlinkToLocalBin(wrapper: File): File {
+        val localBin = File(SystemUtils.getUserHome(), ".local/bin")
+        localBin.mkdirs()
+        val link = File(localBin, CLI_NAME)
+        Files.deleteIfExists(link.toPath())
+        return runCatching {
+            Files.createSymbolicLink(link.toPath(), wrapper.toPath()).toFile()
+        }.getOrElse {
+            // 某些文件系统不支持软链 → 复制 wrapper 内容
+            wrapper.copyTo(link, overwrite = true)
+            link
+        }
+    }
+}

--- a/src/main/kotlin/app/termora/plugin/internal/cli/SkillInstaller.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/cli/SkillInstaller.kt
@@ -1,0 +1,37 @@
+package app.termora.plugin.internal.cli
+
+import org.apache.commons.lang3.SystemUtils
+import java.io.File
+
+/**
+ * termora-cli 的 Skill（SKILL.md）安装器。
+ * SKILL.md 作为资源打进 jar（classpath `/skill/termora-cli/SKILL.md`），是唯一来源。
+ * 安装即把它写到目标工具的 skills 目录：<baseDir>/skills/termora-cli/SKILL.md。
+ * Claude Code 与 Codex CLI 都从该结构加载（同一 SKILL.md，不同 baseDir）。
+ */
+object SkillInstaller {
+    const val SKILL_NAME = "termora-cli"
+    private const val RESOURCE = "/skill/termora-cli/SKILL.md"
+
+    /** 读取打包的 SKILL.md 文本 */
+    fun readSkill(): String {
+        val stream = SkillInstaller::class.java.getResourceAsStream(RESOURCE)
+            ?: throw IllegalStateException("SKILL resource not found: $RESOURCE")
+        return stream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+    }
+
+    /** 写到 <baseDir>/skills/termora-cli/SKILL.md，覆盖已存在文件，返回写入的文件 */
+    fun installTo(baseDir: File): File {
+        val dir = File(baseDir, "skills/$SKILL_NAME")
+        dir.mkdirs()
+        val file = File(dir, "SKILL.md")
+        file.writeText(readSkill(), Charsets.UTF_8)
+        return file
+    }
+
+    /** Claude Code 个人 skills 根目录 ~/.claude */
+    fun claudeBaseDir(): File = File(SystemUtils.getUserHome(), ".claude")
+
+    /** Codex CLI 个人 skills 根目录 ~/.codex */
+    fun codexBaseDir(): File = File(SystemUtils.getUserHome(), ".codex")
+}

--- a/src/main/kotlin/app/termora/plugin/internal/cli/WhitelistStore.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/cli/WhitelistStore.kt
@@ -1,0 +1,34 @@
+package app.termora.plugin.internal.cli
+
+import app.termora.Application.ohMyJson
+import app.termora.cli.guard.WhitelistManager
+
+/**
+ * termora-cli 主机白名单的读写封装。白名单是 host id 列表，存数据库 setting `cli.whitelist`（JSON 数组）。
+ * 与 CLI 侧 [WhitelistManager] 读取的是同一 key，保证 GUI 写入 = CLI 读取。
+ * 读取直接复用 [WhitelistManager]，避免 JSON 解析逻辑重复。
+ *
+ * @param read  返回 cli.whitelist 原始 JSON；生产用 DatabaseManager.properties.getString(KEY,"[]")
+ * @param write 写入 cli.whitelist 原始 JSON；生产用 DatabaseManager.properties.putString(KEY, _)
+ */
+class WhitelistStore(
+    read: () -> String,
+    private val write: (String) -> Unit,
+) {
+    private val manager = WhitelistManager(read)
+
+    fun ids(): Set<String> = manager.ids()
+
+    fun isEnabled(id: String): Boolean = manager.isAllowed(id)
+
+    fun setEnabled(id: String, enabled: Boolean) {
+        val current = manager.ids().toMutableSet()
+        if (enabled) current.add(id) else current.remove(id)
+        write(ohMyJson.encodeToString(current.toList()))
+    }
+
+    companion object {
+        /** 复用 CLI 侧的 key，避免读写不一致 */
+        val SETTING_KEY: String get() = WhitelistManager.SETTING_KEY
+    }
+}

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -35,6 +35,26 @@ termora.host.modified-server-key.are-you-sure=Are you sure you want to continue 
 # Settings
 termora.setting=Settings
 
+termora.settings.cli=Command Line
+termora.settings.cli.enable=Enable termora-cli
+termora.settings.cli.enable.tip=When off, termora-cli refuses all commands.
+termora.settings.cli.whitelist.tip=Select which hosts termora-cli is allowed to access:
+termora.settings.cli.whitelist.empty=No hosts yet.
+termora.settings.cli.skill.copy=Copy Skill
+termora.settings.cli.skill.install.claude=Install to Claude
+termora.settings.cli.skill.install.codex=Install to Codex
+termora.settings.cli.skill.copied=Skill copied to clipboard.
+termora.settings.cli.skill.installed=Installed to: {0}
+termora.settings.cli.skill.failed=Install failed: {0}
+termora.settings.cli.whitelist.ssh-only=SSH only
+termora.settings.cli.path.add=Add to PATH
+termora.settings.cli.path.remove=Remove from PATH
+termora.settings.cli.path.added=termora-cli added to PATH ({0}). Open a NEW terminal to use it.
+termora.settings.cli.path.removed=termora-cli removed from PATH.
+termora.settings.cli.path.dev-note=Note: running from a dev build — the launcher uses the current classpath and may stop working after a rebuild. For permanent use, install the packaged app.
+termora.settings.cli.path.portable-note=Portable build detected: if you move the Termora folder or change its drive letter, termora-cli will stop working — just click "Add to PATH" again after moving.
+termora.settings.cli.path.failed=Operation failed: {0}
+
 termora.settings.appearance=General
 termora.settings.appearance.theme=Theme
 termora.settings.appearance.layout=Layout

--- a/src/main/resources/i18n/messages_de_DE.properties
+++ b/src/main/resources/i18n/messages_de_DE.properties
@@ -35,6 +35,26 @@ termora.host.modified-server-key.are-you-sure=Möchtest du die Verbindung trotzd
 # Settings
 termora.setting=Einstellungen
 
+termora.settings.cli=Befehlszeile
+termora.settings.cli.enable=termora-cli aktivieren
+termora.settings.cli.enable.tip=Wenn deaktiviert, lehnt termora-cli alle Befehle ab.
+termora.settings.cli.whitelist.tip=Wähle aus, auf welche Hosts termora-cli zugreifen darf:
+termora.settings.cli.whitelist.empty=Noch keine Hosts.
+termora.settings.cli.skill.copy=Skill kopieren
+termora.settings.cli.skill.install.claude=In Claude installieren
+termora.settings.cli.skill.install.codex=In Codex installieren
+termora.settings.cli.skill.copied=Skill in die Zwischenablage kopiert.
+termora.settings.cli.skill.installed=Installiert nach: {0}
+termora.settings.cli.skill.failed=Installation fehlgeschlagen: {0}
+termora.settings.cli.whitelist.ssh-only=Nur SSH
+termora.settings.cli.path.add=Zu PATH hinzufügen
+termora.settings.cli.path.remove=Aus PATH entfernen
+termora.settings.cli.path.added=termora-cli wurde zu PATH hinzugefügt ({0}). Öffne ein NEUES Terminal, um es zu verwenden.
+termora.settings.cli.path.removed=termora-cli wurde aus PATH entfernt.
+termora.settings.cli.path.dev-note=Hinweis: Ausführung aus einem Dev-Build — der Launcher verwendet den aktuellen Classpath und funktioniert nach einem Neubau möglicherweise nicht mehr. Für dauerhafte Nutzung die paketierte App installieren.
+termora.settings.cli.path.portable-note=Portable Version erkannt: Wenn du den Termora-Ordner verschiebst oder den Laufwerksbuchstaben änderst, funktioniert termora-cli nicht mehr — klicke nach dem Verschieben einfach erneut auf „Zu PATH hinzufügen".
+termora.settings.cli.path.failed=Vorgang fehlgeschlagen: {0}
+
 termora.settings.appearance=Darstellung
 termora.settings.appearance.theme=Design
 termora.settings.appearance.layout=Anordnung

--- a/src/main/resources/i18n/messages_pt_BR.properties
+++ b/src/main/resources/i18n/messages_pt_BR.properties
@@ -35,6 +35,26 @@ termora.host.modified-server-key.are-you-sure=Tem certeza de que deseja continua
 # Settings
 termora.setting=Configurações
 
+termora.settings.cli=Linha de comando
+termora.settings.cli.enable=Ativar termora-cli
+termora.settings.cli.enable.tip=Quando desativado, o termora-cli recusa todos os comandos.
+termora.settings.cli.whitelist.tip=Selecione quais hosts o termora-cli pode acessar:
+termora.settings.cli.whitelist.empty=Nenhum host ainda.
+termora.settings.cli.skill.copy=Copiar Skill
+termora.settings.cli.skill.install.claude=Instalar no Claude
+termora.settings.cli.skill.install.codex=Instalar no Codex
+termora.settings.cli.skill.copied=Skill copiada para a área de transferência.
+termora.settings.cli.skill.installed=Instalado em: {0}
+termora.settings.cli.skill.failed=Falha na instalação: {0}
+termora.settings.cli.whitelist.ssh-only=Apenas SSH
+termora.settings.cli.path.add=Adicionar ao PATH
+termora.settings.cli.path.remove=Remover do PATH
+termora.settings.cli.path.added=termora-cli adicionado ao PATH ({0}). Abra um NOVO terminal para usá-lo.
+termora.settings.cli.path.removed=termora-cli removido do PATH.
+termora.settings.cli.path.dev-note=Nota: executando a partir de uma build de desenvolvimento — o launcher usa o classpath atual e pode parar de funcionar após uma recompilação. Para uso permanente, instale o aplicativo empacotado.
+termora.settings.cli.path.portable-note=Build portátil detectada: se você mover a pasta do Termora ou alterar a letra da unidade, o termora-cli deixará de funcionar — basta clicar em "Adicionar ao PATH" novamente após mover.
+termora.settings.cli.path.failed=Operação falhou: {0}
+
 termora.settings.appearance=Geral
 termora.settings.appearance.theme=Tema
 termora.settings.appearance.layout=Layout

--- a/src/main/resources/i18n/messages_ru_RU.properties
+++ b/src/main/resources/i18n/messages_ru_RU.properties
@@ -32,6 +32,26 @@ termora.host.modified-server-key.are-you-sure=Вы уверены, что хот
 # Settings
 termora.setting=Настройки
 
+termora.settings.cli=Командная строка
+termora.settings.cli.enable=Включить termora-cli
+termora.settings.cli.enable.tip=Когда выключено, termora-cli отклоняет все команды.
+termora.settings.cli.whitelist.tip=Выберите, к каким хостам разрешён доступ termora-cli:
+termora.settings.cli.whitelist.empty=Хостов пока нет.
+termora.settings.cli.skill.copy=Копировать Skill
+termora.settings.cli.skill.install.claude=Установить в Claude
+termora.settings.cli.skill.install.codex=Установить в Codex
+termora.settings.cli.skill.copied=Skill скопирован в буфер обмена.
+termora.settings.cli.skill.installed=Установлено в: {0}
+termora.settings.cli.skill.failed=Не удалось установить: {0}
+termora.settings.cli.whitelist.ssh-only=Только SSH
+termora.settings.cli.path.add=Добавить в PATH
+termora.settings.cli.path.remove=Удалить из PATH
+termora.settings.cli.path.added=termora-cli добавлен в PATH ({0}). Откройте НОВЫЙ терминал, чтобы использовать его.
+termora.settings.cli.path.removed=termora-cli удалён из PATH.
+termora.settings.cli.path.dev-note=Примечание: запуск из dev-сборки — лаунчер использует текущий classpath и может перестать работать после пересборки. Для постоянного использования установите упакованное приложение.
+termora.settings.cli.path.portable-note=Обнаружена портативная сборка: если вы переместите папку Termora или измените букву диска, termora-cli перестанет работать — после перемещения просто снова нажмите «Добавить в PATH».
+termora.settings.cli.path.failed=Операция не удалась: {0}
+
 termora.settings.appearance=Внешний вид
 termora.settings.appearance.theme=Тема
 termora.settings.appearance.language=Язык

--- a/src/main/resources/i18n/messages_zh_CN.properties
+++ b/src/main/resources/i18n/messages_zh_CN.properties
@@ -39,6 +39,26 @@ termora.settings.restart.title=重启
 termora.settings.restart.message=设置修改将在重启后生效
 termora.settings.restart.manually=请手动重启软件
 
+termora.settings.cli=命令行工具
+termora.settings.cli.enable=启用 termora-cli
+termora.settings.cli.enable.tip=关闭时，termora-cli 拒绝执行任何命令。
+termora.settings.cli.whitelist.tip=勾选允许 termora-cli 访问的主机：
+termora.settings.cli.whitelist.empty=暂无主机。
+termora.settings.cli.skill.copy=复制 Skill
+termora.settings.cli.skill.install.claude=安装到 Claude
+termora.settings.cli.skill.install.codex=安装到 Codex
+termora.settings.cli.skill.copied=Skill 已复制到剪贴板。
+termora.settings.cli.skill.installed=已安装到：{0}
+termora.settings.cli.skill.failed=安装失败：{0}
+termora.settings.cli.whitelist.ssh-only=仅支持 SSH
+termora.settings.cli.path.add=添加到 PATH
+termora.settings.cli.path.remove=从 PATH 移除
+termora.settings.cli.path.added=termora-cli 已添加到 PATH（{0}）。请打开一个新终端后使用。
+termora.settings.cli.path.removed=termora-cli 已从 PATH 移除。
+termora.settings.cli.path.dev-note=注意：当前为开发版运行，wrapper 使用当前 classpath，重新构建后可能失效。长期使用请用安装版。
+termora.settings.cli.path.portable-note=检测到便携版：若移动 Termora 文件夹或更换盘符，termora-cli 将失效——移动后重新点一次「添加到 PATH」即可。
+termora.settings.cli.path.failed=操作失败：{0}
+
 termora.settings.appearance=常规
 termora.settings.appearance.theme=主题
 termora.settings.appearance.layout=布局

--- a/src/main/resources/i18n/messages_zh_TW.properties
+++ b/src/main/resources/i18n/messages_zh_TW.properties
@@ -38,6 +38,26 @@ termora.settings.restart.title=重啟
 termora.settings.restart.message=設定修改將在重新啟動後生效
 termora.settings.restart.manually=請手動重新啟動軟體
 
+termora.settings.cli=命令列工具
+termora.settings.cli.enable=啟用 termora-cli
+termora.settings.cli.enable.tip=關閉時，termora-cli 拒絕執行任何命令。
+termora.settings.cli.whitelist.tip=勾選允許 termora-cli 存取的主機：
+termora.settings.cli.whitelist.empty=暫無主機。
+termora.settings.cli.skill.copy=複製 Skill
+termora.settings.cli.skill.install.claude=安裝到 Claude
+termora.settings.cli.skill.install.codex=安裝到 Codex
+termora.settings.cli.skill.copied=Skill 已複製到剪貼簿。
+termora.settings.cli.skill.installed=已安裝到：{0}
+termora.settings.cli.skill.failed=安裝失敗：{0}
+termora.settings.cli.whitelist.ssh-only=僅支援 SSH
+termora.settings.cli.path.add=新增到 PATH
+termora.settings.cli.path.remove=從 PATH 移除
+termora.settings.cli.path.added=termora-cli 已新增到 PATH（{0}）。請開啟一個新終端機後使用。
+termora.settings.cli.path.removed=termora-cli 已從 PATH 移除。
+termora.settings.cli.path.dev-note=注意：目前為開發版執行，wrapper 使用目前 classpath，重新建置後可能失效。長期使用請用安裝版。
+termora.settings.cli.path.portable-note=偵測到可攜版：若移動 Termora 資料夾或更換磁碟機代號，termora-cli 將失效——移動後重新點一次「新增到 PATH」即可。
+termora.settings.cli.path.failed=操作失敗：{0}
+
 termora.settings.appearance=一般
 termora.settings.appearance.theme=主题
 termora.settings.appearance.layout=佈局

--- a/src/main/resources/skill/termora-cli/SKILL.md
+++ b/src/main/resources/skill/termora-cli/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: termora-cli
+description: This skill should be used when the user asks to "connect to a server", "SSH into a machine", "run a command on a remote host", "list SSH assets/hosts", "upload/download files to a server", or mentions the `termora-cli` command — including Chinese phrasings like "连接服务器"、"登录某台机器跑命令"、"上传/下载文件到服务器"、"列出主机". Use `termora-cli` instead of running `ssh`, `scp`, or `sftp` directly.
+---
+
+# Termora CLI
+
+Use the `termora-cli` command to list SSH assets, run one-off commands, and transfer files through the host configurations the user has already saved in their **Termora** desktop app.
+
+Prefer `termora-cli` over running `ssh`, `scp`, or `sftp` directly. Termora holds the credentials and connects using saved configurations, so you never need to ask the user for passwords, private keys, or passphrases.
+
+Run `termora-cli --help` to discover commands. Output format is decided automatically by whether stdout is a TTY: when piped or captured programmatically it prints **JSON**, in an interactive terminal it prints human-readable text. You normally do **not** need to pass `--json` — it is accepted only by `assets list` as a compatibility placeholder and does not change the output; `exec`/`upload`/`download` do not accept `--json` (writing it would be treated as part of the command).
+
+## Common Workflow
+
+```bash
+termora-cli assets list -q <keyword>               # find which hosts you may use (by name/host/remark)
+termora-cli exec <asset-id> "<command>"            # run one command on that host
+termora-cli upload <asset-id> <local> <remote>     # send a file to the host
+termora-cli download <asset-id> <remote> <local>   # fetch a file from the host
+```
+
+Always start with `assets list` to discover the `<asset-id>` to use. **Only hosts the user has explicitly allowed for termora-cli access are listed** — if a host you expect is missing, ask the user to enable it in Termora first (Settings →「命令行工具」/ Command Line, then check that host).
+
+Each listed asset includes a `protocol` field. `exec`, `upload`, and `download` work over SSH only — when choosing an id, confirm its `protocol` is `SSH` (using these commands on a non-SSH asset will fail to connect, exit code 5).
+
+## Running Commands
+
+`termora-cli exec` takes an asset id and one complete remote shell command string, opens a temporary SSH connection, runs the command, and closes the connection. It is **stateless** — each call is a fresh connection, so `cd`, `export`, and shell state do **not** persist between calls. Combine steps in a single command when you need shared state:
+
+```bash
+termora-cli exec <asset-id> "cd /var/log && tail -n 50 syslog"
+```
+
+For simple commands, pass one complete remote shell command string as `<command>`.
+
+When running from **Windows PowerShell**, pass complex commands through stdin if they contain quotes, pipes, redirects, JSON, `$`, backticks, or nested shell code — this avoids PowerShell's quoting pitfalls:
+
+```powershell
+@'
+<command>
+'@ | termora-cli exec <asset-id> --stdin
+```
+
+In Windows PowerShell, pass simple commands as one quoted `<command>` and do **not** split command words into multiple arguments. For anything complex, use `--stdin` with a single-quoted here-string instead.
+
+## File Transfer
+
+```bash
+termora-cli upload <asset-id> ./app.tar.gz /tmp/release.tar.gz
+termora-cli download <asset-id> /tmp/app.tar.gz ./latest.tar.gz
+```
+
+Destination paths follow **scp-style** behavior: if the destination exists and is a directory, the source keeps its name inside that directory; otherwise the destination path is used as the final file path. Transfers are currently **single-file** (folder recursion is not yet supported).
+
+## Exit Codes
+
+`termora-cli` exits non-zero on failure. Read the exit code to decide what to do next:
+
+| Code | Meaning | What to do |
+|------|---------|-----------|
+| 0 | Success | — |
+| 1 | Usage error | Fix the command syntax |
+| 2 | Asset not found | Re-run `assets list` to get a valid id |
+| 3 | Host not allowed (not whitelisted) | Ask the user to allow that host for termora-cli in Termora (Settings → Command Line) |
+| 4 | Dangerous command blocked | The command matched a destructive-command guard (e.g. `rm -rf /`, `mkfs`, `shutdown`); rephrase or confirm intent with the user |
+| 5 | Connection / execution failed | See "First-connection failures" below |
+| 6 | termora-cli is disabled | Ask the user to turn on "Enable termora-cli" in Termora settings → Command Line |
+
+**Important — `exec` passes through the remote command's exit code.** Once the connection and authentication succeed, `termora-cli exec` exits with the **remote command's own exit status** (e.g. a remote `grep` with no match exits 1, `command not found` exits 127), which can be greater than 5. An exit code of **255** means the remote exit status could not be obtained (the connection itself succeeded). Therefore the 1–5 meanings above apply to `termora-cli`'s **own** failures (usage / not-found / not-allowed / dangerous / connection); to judge whether the remote command actually ran and succeeded, **prefer reading the `exitCode` and `stderr` fields in the JSON output** rather than the process exit code alone. `upload`/`download` only ever exit 0 (success) or 5 (failure); they do not pass through other codes.
+
+## Rules & Caveats
+
+- **Never ask the user for SSH passwords, private keys, or passphrases.** Termora holds those and connects via saved configurations.
+- **Whitelist:** only hosts the user has allowed for termora-cli access are reachable. `assets list` shows exactly those; any other id returns exit code 3.
+- **Dangerous commands are blocked** (exit code 4) as a guardrail against accidents — it is a conservative string-level check, not a full sandbox. If you genuinely need such an operation, confirm with the user and have them run it.
+- **Audit:** every command and transfer is logged by Termora. Assume your actions are recorded.
+- **Long-running tasks** should be detached on the remote host with `tmux`, `nohup`, or `systemd` — since `exec` closes the connection when the command returns, a foreground long task would be tied to that single call.
+- **Disabled state:** if any command exits with code 6, termora-cli is turned off — ask the user to enable it in Termora (Settings → Command Line) before retrying.
+
+### First-connection failures (exit code 5)
+
+`termora-cli` runs without Termora's GUI prompts. A host that needs **interactive input on first connect** can therefore fail, specifically:
+
+- a server that only offers **keyboard-interactive** authentication, or
+- a host whose **key/passphrase or host-key trust** has never been established.
+
+If `exec`/`upload`/`download` fails to connect, ask the user to **open that host once in the Termora GUI** to cache trust/credentials, then retry.

--- a/src/test/kotlin/app/termora/cli/AssetListerTest.kt
+++ b/src/test/kotlin/app/termora/cli/AssetListerTest.kt
@@ -1,0 +1,53 @@
+package app.termora.cli
+
+import app.termora.Host
+import app.termora.cli.guard.WhitelistManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AssetListerTest {
+    private fun host(id: String, name: String, remark: String = "") =
+        Host(id = id, name = name, protocol = "SSH", host = "10.0.0.1", port = 22, username = "root", remark = remark)
+
+    private fun lister(hosts: List<Host>, allow: List<String>) = AssetLister(
+        hostsProvider = { hosts },
+        whitelist = WhitelistManager { allow.joinToString(prefix = "[", postfix = "]") { "\"$it\"" } },
+    )
+
+    @Test
+    fun `只列白名单内的主机`() {
+        val hosts = listOf(host("a", "web-01"), host("b", "db-01"))
+        val result = lister(hosts, listOf("a")).list()
+        assertEquals(1, result.size)
+        assertEquals("web-01", result[0].name)
+        assertEquals("a", result[0].id)
+    }
+
+    @Test
+    fun `过滤文件夹与已删除节点`() {
+        val folder = Host(id = "f", name = "组", protocol = "Folder")
+        val deleted = host("d", "old").copy(deleted = true)
+        val ok = host("a", "web-01")
+        val result = lister(listOf(folder, deleted, ok), listOf("f", "d", "a")).list()
+        assertEquals(listOf("web-01"), result.map { it.name })
+    }
+
+    @Test
+    fun `关键字匹配 name host remark 且忽略大小写`() {
+        val hosts = listOf(
+            host("a", "web-01", remark = "生产"),
+            host("b", "db-01", remark = "测试"),
+        )
+        val result = lister(hosts, listOf("a", "b")).list("WEB")
+        assertEquals(listOf("web-01"), result.map { it.name })
+        assertEquals(listOf("db-01"), lister(hosts, listOf("a", "b")).list("测试").map { it.name })
+    }
+
+    @Test
+    fun `不泄露凭证字段`() {
+        // AssetInfo 没有 authentication/password 字段——编译期即保证；这里确认映射只取安全字段
+        val result = lister(listOf(host("a", "web-01")), listOf("a")).list()
+        assertTrue(result[0].username == "root" && result[0].host == "10.0.0.1")
+    }
+}

--- a/src/test/kotlin/app/termora/cli/AuditorTest.kt
+++ b/src/test/kotlin/app/termora/cli/AuditorTest.kt
@@ -1,0 +1,23 @@
+package app.termora.cli
+
+import app.termora.cli.guard.Auditor
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AuditorTest {
+    @Test
+    fun `追加两行审计记录`() {
+        val file = Files.createTempFile("cli-audit", ".log").toFile()
+        val auditor = Auditor(file)
+
+        auditor.record("h1", "web-01", "exec", "ls", 0)
+        auditor.record("h1", "web-01", "exec", "rm -rf /", 4)
+
+        val lines = file.readLines().filter { it.isNotBlank() }
+        assertEquals(2, lines.size)
+        assertTrue(lines[0].contains("\"command\":\"ls\""))
+        assertTrue(lines[1].contains("\"exitCode\":4"))
+    }
+}

--- a/src/test/kotlin/app/termora/cli/CliOutputAssetsTest.kt
+++ b/src/test/kotlin/app/termora/cli/CliOutputAssetsTest.kt
@@ -1,0 +1,38 @@
+package app.termora.cli
+
+import app.termora.cli.output.CliOutput
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class CliOutputAssetsTest {
+    private val assets = listOf(
+        AssetInfo("a", "web-01", "SSH", "10.0.0.1", 22, "root", "生产"),
+        AssetInfo("b", "db-01", "SSH", "10.0.0.2", 2222, "admin", ""),
+    )
+
+    @Test
+    fun `assets json 模式输出 assets 数组`() {
+        val text = CliOutput(json = true).renderAssets(assets)
+        assertTrue(text.contains("\"assets\""))
+        assertTrue(text.contains("\"id\":\"a\""))
+        assertTrue(text.contains("\"name\":\"web-01\""))
+        // 不含凭证字段
+        assertTrue(!text.contains("password") && !text.contains("authentication"))
+    }
+
+    @Test
+    fun `assets 人类可读模式每行含 name 与 hostport`() {
+        val text = CliOutput(json = false).renderAssets(assets)
+        assertTrue(text.contains("web-01"))
+        assertTrue(text.contains("10.0.0.1:22"))
+        assertTrue(text.contains("db-01"))
+    }
+
+    @Test
+    fun `transfer json 模式输出 ok 与 bytes`() {
+        val r = TransferResult(ok = true, bytes = 123, host = "web-01")
+        val text = CliOutput(json = true).renderTransfer(r)
+        assertTrue(text.contains("\"ok\":true"))
+        assertTrue(text.contains("\"bytes\":123"))
+    }
+}

--- a/src/test/kotlin/app/termora/cli/CliOutputTest.kt
+++ b/src/test/kotlin/app/termora/cli/CliOutputTest.kt
@@ -1,0 +1,39 @@
+package app.termora.cli
+
+import app.termora.cli.output.CliOutput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CliOutputTest {
+    @Test
+    fun `json 模式输出可解析的 ExecResult`() {
+        val out = CliOutput(json = true)
+        val r = ExecResult(exitCode = 0, stdout = "hi\n", stderr = "", host = "web-01", durationMs = 12)
+        val text = out.renderExec(r)
+        assertTrue(text.contains("\"exitCode\":0"))
+        assertTrue(text.contains("\"host\":\"web-01\""))
+    }
+
+    @Test
+    fun `人类可读模式输出 stdout 原文`() {
+        val out = CliOutput(json = false)
+        val r = ExecResult(exitCode = 0, stdout = "hello\n", stderr = "", host = "web-01", durationMs = 12)
+        val text = out.renderExec(r)
+        assertTrue(text.contains("hello"))
+    }
+
+    @Test
+    fun `人类可读模式 stdout 与 stderr 同时输出且 stderr 接在 stdout 之后`() {
+        val out = CliOutput(json = false)
+        // stdout 不以换行结尾，覆盖分隔符补 \n 的拼接分支
+        val r = ExecResult(exitCode = 1, stdout = "out-text", stderr = "err-text", host = "web-01", durationMs = 12)
+        val text = out.renderExec(r)
+        assertTrue(text.contains("out-text"))
+        assertTrue(text.contains("err-text"))
+        // stderr 必须排在 stdout 之后
+        assertTrue(text.indexOf("out-text") < text.indexOf("err-text"))
+        // 二者之间补了换行
+        assertEquals("out-text\nerr-text", text)
+    }
+}

--- a/src/test/kotlin/app/termora/cli/DangerousCommandFilterTest.kt
+++ b/src/test/kotlin/app/termora/cli/DangerousCommandFilterTest.kt
@@ -1,0 +1,55 @@
+package app.termora.cli
+
+import app.termora.cli.guard.DangerousCommandFilter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DangerousCommandFilterTest {
+    private val filter = DangerousCommandFilter()
+
+    @Test
+    fun `放行普通命令`() {
+        assertNull(filter.match("ls -la /var/log"))
+        assertNull(filter.match("df -h"))
+        assertNull(filter.match("systemctl status nginx"))
+    }
+
+    @Test
+    fun `拦截 rm -rf 根目录`() {
+        assertEquals("rm-rf-root", filter.match("rm -rf /"))
+        assertEquals("rm-rf-root", filter.match("rm -fr /"))
+        assertEquals("rm-rf-root", filter.match("rm -Rf /"))
+        assertEquals("rm-rf-root", filter.match("rm -rfv /"))
+        assertEquals("rm-rf-root", filter.match("rm -fr ~"))
+        assertEquals("rm-rf-root", filter.match("sudo rm  -rf   /*"))
+    }
+
+    @Test
+    fun `拦截 mkfs 与 dd 写设备`() {
+        assertEquals("mkfs", filter.match("mkfs.ext4 /dev/sdb1"))
+        assertEquals("dd-to-device", filter.match("dd if=/dev/zero of=/dev/sda"))
+    }
+
+    @Test
+    fun `拦截关机重启与 fork bomb`() {
+        assertEquals("shutdown", filter.match("shutdown -h now"))
+        assertEquals("shutdown", filter.match("reboot"))
+        assertEquals("shutdown", filter.match("sudo reboot"))
+        assertEquals("fork-bomb", filter.match(":(){ :|:& };:"))
+    }
+
+    @Test
+    fun `关机重启关键字作为子串时放行`() {
+        assertNull(filter.match("cat halt.txt"))
+        assertNull(filter.match("echo reboot now"))
+        assertNull(filter.match("grep poweroff /var/log/x"))
+    }
+
+    @Test
+    fun `拦截重定向到设备与 chmod chown 根目录`() {
+        assertEquals("redirect-to-device", filter.match("echo x > /dev/sda"))
+        assertEquals("chmod-root", filter.match("chmod -R 777 /"))
+        assertEquals("chown-root", filter.match("chown -R user /"))
+    }
+}

--- a/src/test/kotlin/app/termora/cli/HostTreeBuilderTest.kt
+++ b/src/test/kotlin/app/termora/cli/HostTreeBuilderTest.kt
@@ -1,0 +1,60 @@
+package app.termora.cli
+
+import app.termora.Host
+import app.termora.plugin.internal.cli.HostTreeBuilder
+import javax.swing.tree.DefaultMutableTreeNode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HostTreeBuilderTest {
+    private fun folder(id: String, name: String, parent: String = "0", sort: Long = 0) =
+        Host(id = id, name = name, protocol = "Folder", parentId = parent, sort = sort)
+
+    private fun host(id: String, name: String, parent: String = "0", sort: Long = 0) =
+        Host(id = id, name = name, protocol = "SSH", host = "10.0.0.1", port = 22, username = "root", parentId = parent, sort = sort)
+
+    private fun childHosts(node: DefaultMutableTreeNode): List<Host> =
+        (0 until node.childCount).map { (node.getChildAt(it) as DefaultMutableTreeNode).userObject as Host }
+
+    @Test
+    fun `顶层主机挂在 root 下`() {
+        val root = HostTreeBuilder.build(listOf(host("a", "web-01")))
+        assertEquals(1, root.childCount)
+        assertEquals("web-01", childHosts(root)[0].name)
+    }
+
+    @Test
+    fun `主机挂在其所属文件夹下`() {
+        val root = HostTreeBuilder.build(listOf(folder("f", "生产"), host("a", "web-01", parent = "f")))
+        assertEquals(1, root.childCount)
+        val folderNode = root.getChildAt(0) as DefaultMutableTreeNode
+        assertEquals("生产", (folderNode.userObject as Host).name)
+        assertEquals(listOf("web-01"), childHosts(folderNode).map { it.name })
+    }
+
+    @Test
+    fun `过滤已删除节点`() {
+        val root = HostTreeBuilder.build(listOf(host("a", "web-01"), host("b", "old").copy(deleted = true)))
+        assertEquals(listOf("web-01"), childHosts(root).map { it.name })
+    }
+
+    @Test
+    fun `同层文件夹优先于主机并按 sort 排序`() {
+        val root = HostTreeBuilder.build(
+            listOf(
+                host("h", "host-z", sort = 0),
+                folder("f", "folder-a", sort = 5),
+            )
+        )
+        // 文件夹优先，即使其 sort 更大
+        val names = (0 until root.childCount).map { ((root.getChildAt(it) as DefaultMutableTreeNode).userObject as Host).name }
+        assertEquals(listOf("folder-a", "host-z"), names)
+    }
+
+    @Test
+    fun `父不存在的孤儿挂到 root`() {
+        val root = HostTreeBuilder.build(listOf(host("a", "web-01", parent = "missing")))
+        assertTrue(childHosts(root).any { it.name == "web-01" })
+    }
+}

--- a/src/test/kotlin/app/termora/cli/PathInstallerTest.kt
+++ b/src/test/kotlin/app/termora/cli/PathInstallerTest.kt
@@ -1,0 +1,23 @@
+package app.termora.cli
+
+import app.termora.plugin.internal.cli.PathInstaller
+import com.formdev.flatlaf.util.SystemInfo
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class PathInstallerTest {
+    @Test
+    fun `生成 wrapper 含 java 与 CLI 入口`() {
+        val dir = Files.createTempDirectory("bin").toFile()
+        val wrapper = PathInstaller.generateWrapper(dir)
+
+        assertTrue(wrapper.exists())
+        val expectedName = if (SystemInfo.isWindows) "termora-cli.cmd" else "termora-cli"
+        assertTrue(wrapper.name == expectedName, "实际: ${wrapper.name}")
+
+        val text = wrapper.readText()
+        assertTrue(text.contains("app.termora.cli.CliMainKt"), "wrapper 应调用 CLI 入口")
+        assertTrue(text.contains("java"), "wrapper 应引用 java")
+    }
+}

--- a/src/test/kotlin/app/termora/cli/SftpTransferIT.kt
+++ b/src/test/kotlin/app/termora/cli/SftpTransferIT.kt
@@ -1,0 +1,59 @@
+package app.termora.cli
+
+import app.termora.Host
+import app.termora.SSHDTest
+import app.termora.cli.guard.Auditor
+import app.termora.cli.guard.WhitelistManager
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class SftpTransferIT : SSHDTest() {
+
+    private fun transfer(h: Host, allow: List<String>): SftpTransfer {
+        val auditFile = Files.createTempFile("audit", ".log").toFile()
+        return SftpTransfer(
+            hostResolver = { id -> if (id == h.id) h else null },
+            whitelist = WhitelistManager { allow.joinToString(prefix = "[", postfix = "]") { "\"$it\"" } },
+            auditor = Auditor(auditFile),
+        )
+    }
+
+    @Test
+    fun `上传后下载内容一致`() {
+        val h = host
+        val t = transfer(h, listOf(h.id))
+
+        val local = Files.createTempFile("up", ".txt")
+        Files.writeString(local, "hello-sftp")
+        val remote = "/tmp/termora-cli-it.txt"
+
+        val up = t.upload(h.id, local.toString(), remote)
+        assertTrue(up.ok && up.bytes > 0)
+
+        val back = Files.createTempFile("down", ".txt")
+        val down = t.download(h.id, remote, back.toString())
+        assertTrue(down.ok)
+        assertEquals("hello-sftp", Files.readString(back))
+    }
+
+    @Test
+    fun `非白名单主机上传被拒绝`() {
+        val h = host
+        val t = transfer(h, emptyList())
+        val local = Files.createTempFile("up", ".txt")
+        val e = assertFailsWith<CliError> { t.upload(h.id, local.toString(), "/tmp/x.txt") }
+        assertEquals(ExitCodes.FORBIDDEN, e.code)
+    }
+
+    @Test
+    fun `未知主机报 NOT_FOUND`() {
+        val h = host
+        val t = transfer(h, listOf(h.id))
+        val local = Files.createTempFile("up", ".txt")
+        val e = assertFailsWith<CliError> { t.upload("nope", local.toString(), "/tmp/x.txt") }
+        assertEquals(ExitCodes.NOT_FOUND, e.code)
+    }
+}

--- a/src/test/kotlin/app/termora/cli/SkillInstallerTest.kt
+++ b/src/test/kotlin/app/termora/cli/SkillInstallerTest.kt
@@ -1,0 +1,37 @@
+package app.termora.cli
+
+import app.termora.plugin.internal.cli.SkillInstaller
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SkillInstallerTest {
+    @Test
+    fun `读取打包在 jar 里的 SKILL`() {
+        val text = SkillInstaller.readSkill()
+        assertTrue(text.contains("name: termora-cli"))
+        assertTrue(text.contains("termora-cli exec"))
+    }
+
+    @Test
+    fun `安装到指定目录写出 skills termora-cli SKILL`() {
+        val base = Files.createTempDirectory("install-test").toFile()
+        val file = SkillInstaller.installTo(base)
+
+        assertEquals("SKILL.md", file.name)
+        // 父目录应为 <base>/skills/termora-cli
+        val parent = file.parentFile.path.replace('\\', '/')
+        assertTrue(parent.endsWith("skills/termora-cli"), "实际父目录: $parent")
+        // 内容与资源一致
+        assertEquals(SkillInstaller.readSkill(), file.readText())
+    }
+
+    @Test
+    fun `重复安装覆盖且内容一致`() {
+        val base = Files.createTempDirectory("install-test").toFile()
+        SkillInstaller.installTo(base)
+        val file = SkillInstaller.installTo(base) // 第二次
+        assertEquals(SkillInstaller.readSkill(), file.readText())
+    }
+}

--- a/src/test/kotlin/app/termora/cli/SshExecutorIT.kt
+++ b/src/test/kotlin/app/termora/cli/SshExecutorIT.kt
@@ -1,0 +1,70 @@
+package app.termora.cli
+
+import app.termora.Host
+import app.termora.SSHDTest
+import app.termora.cli.guard.Auditor
+import app.termora.cli.guard.DangerousCommandFilter
+import app.termora.cli.guard.WhitelistManager
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class SshExecutorIT : SSHDTest() {
+
+    // 注意：SSHDTest.host 是 get() 计算属性，每次访问都会 new 一个 id 随机的 Host。
+    // 因此每个测试只取一次实例（val h = host）并贯穿始终，保证白名单 id 与 execute 传入的 id 是同一个。
+    private fun newExecutor(h: Host): SshExecutor {
+        val auditFile = Files.createTempFile("audit", ".log").toFile()
+        return SshExecutor(
+            hostResolver = { id -> if (id == h.id) h else null },
+            whitelist = WhitelistManager { """["${h.id}"]""" },
+            dangerous = DangerousCommandFilter(),
+            auditor = Auditor(auditFile),
+        )
+    }
+
+    @Test
+    fun `执行 echo 拿到 stdout 与退出码 0`() {
+        val h = host
+        val r = newExecutor(h).execute(h.id, "echo hello")
+        assertEquals(0, r.exitCode)
+        assertTrue(r.stdout.contains("hello"))
+    }
+
+    @Test
+    fun `执行失败命令拿到非零退出码`() {
+        val h = host
+        val r = newExecutor(h).execute(h.id, "exit 7")
+        assertEquals(7, r.exitCode)
+    }
+
+    @Test
+    fun `非白名单主机被拒绝`() {
+        val h = host
+        val auditFile = Files.createTempFile("audit", ".log").toFile()
+        val exec = SshExecutor(
+            hostResolver = { h },
+            whitelist = WhitelistManager { "[]" },
+            dangerous = DangerousCommandFilter(),
+            auditor = Auditor(auditFile),
+        )
+        val e = assertFailsWith<CliError> { exec.execute(h.id, "echo hi") }
+        assertEquals(ExitCodes.FORBIDDEN, e.code)
+    }
+
+    @Test
+    fun `危险命令被拦截`() {
+        val h = host
+        val e = assertFailsWith<CliError> { newExecutor(h).execute(h.id, "rm -rf /") }
+        assertEquals(ExitCodes.DANGEROUS, e.code)
+    }
+
+    @Test
+    fun `未知主机报 NOT_FOUND`() {
+        val h = host
+        val e = assertFailsWith<CliError> { newExecutor(h).execute("nope", "echo hi") }
+        assertEquals(ExitCodes.NOT_FOUND, e.code)
+    }
+}

--- a/src/test/kotlin/app/termora/cli/WhitelistManagerTest.kt
+++ b/src/test/kotlin/app/termora/cli/WhitelistManagerTest.kt
@@ -1,0 +1,28 @@
+package app.termora.cli
+
+import app.termora.cli.guard.WhitelistManager
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WhitelistManagerTest {
+    @Test
+    fun `空白名单拒绝一切`() {
+        val wm = WhitelistManager { "[]" }
+        assertFalse(wm.isAllowed("host-1"))
+    }
+
+    @Test
+    fun `命中白名单内的主机`() {
+        val wm = WhitelistManager { """["host-1","host-2"]""" }
+        assertTrue(wm.isAllowed("host-1"))
+        assertTrue(wm.isAllowed("host-2"))
+        assertFalse(wm.isAllowed("host-3"))
+    }
+
+    @Test
+    fun `非法或空 JSON 视为空白名单`() {
+        assertFalse(WhitelistManager { "" }.isAllowed("host-1"))
+        assertFalse(WhitelistManager { "not-json" }.isAllowed("host-1"))
+    }
+}

--- a/src/test/kotlin/app/termora/cli/WhitelistStoreTest.kt
+++ b/src/test/kotlin/app/termora/cli/WhitelistStoreTest.kt
@@ -1,0 +1,48 @@
+package app.termora.cli
+
+import app.termora.plugin.internal.cli.WhitelistStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WhitelistStoreTest {
+    private fun store(initial: String = "[]"): Pair<WhitelistStore, () -> String> {
+        var storage = initial
+        val s = WhitelistStore(read = { storage }, write = { storage = it })
+        return s to { storage }
+    }
+
+    @Test
+    fun `空白名单 ids 为空`() {
+        val (s, _) = store()
+        assertTrue(s.ids().isEmpty())
+        assertFalse(s.isEnabled("a"))
+    }
+
+    @Test
+    fun `启用与停用单个主机`() {
+        val (s, raw) = store()
+        s.setEnabled("a", true)
+        assertTrue(s.isEnabled("a"))
+        assertTrue(raw().contains("\"a\""))
+        s.setEnabled("a", false)
+        assertFalse(s.isEnabled("a"))
+    }
+
+    @Test
+    fun `启用幂等且保留其它项`() {
+        val (s, _) = store("""["a"]""")
+        s.setEnabled("b", true)
+        s.setEnabled("b", true) // 幂等
+        assertEquals(setOf("a", "b"), s.ids())
+    }
+
+    @Test
+    fun `非法 JSON 视为空白名单`() {
+        val (s, _) = store("not-json")
+        assertTrue(s.ids().isEmpty())
+        s.setEnabled("a", true) // 从空集恢复写入
+        assertEquals(setOf("a"), s.ids())
+    }
+}


### PR DESCRIPTION
## Summary

Adds `termora-cli`, a command-line entry (shipped via jpackage `--add-launcher`) that lets external AI agents — Claude Code, Codex, etc. — reuse the SSH hosts already saved in Termora to run one-off commands and transfer files, **without ever exposing credentials**. Paired with a bundled `SKILL.md`, an agent can drive it directly.

## Features
- **Commands**: `assets list` / `exec` / `upload` / `download`; JSON output when piped, human-readable in a TTY
- **exec** opens a temporary SSH connection (reuses core `SshClients`, incl. jump hosts) and returns clean stdout/stderr/exit code
- **Defense-in-depth, opt-in (default off)**: master switch + host whitelist (empty by default) + dangerous-command guard + audit log
- **Settings → "Command Line"**: enable switch, tree-grouped host whitelist (non-SSH hosts greyed out), copy / install the Skill to Claude & Codex, add `termora-cli` to PATH
- Bundled `SKILL.md` (a format shared by Claude Code and Codex)

## Design
- **Standalone launcher talking to core directly** (the DB is self-unlocking, so no running GUI is required); no MCP/HTTP layer — kept minimal.
- **Built-in, not an external plugin**: the CLI depends deeply on core SSH/credential handling and the launcher is a build artifact, so it can't be a loadable plugin; optionality is expressed via the default-off master switch.

## Changes
- New `app.termora.cli.**` (CLI core) and `app.termora.plugin.internal.cli.**` (settings UI)
- Core: register an internal plugin in `PluginManager`; widen `ApplicationInitializr.setupNativeLibraries` to `internal` for CLI reuse; `build.gradle.kts` adds `--add-launcher` + `--enable-native-access` and tightens the pty4j native-extraction glob
- i18n for all 6 languages; adds `SKILL.md`

## Testing
- 33 unit tests + 8 integration tests (Testcontainers real sshd)
- Verified end-to-end on Windows: full jpackage build, real-host exec/upload/download (incl. a jump host), master-switch default-off, native warnings suppressed

## Notes for reviewers
- The CLI reuses `SshClients` from the `*.internal.ssh` package (public API, "internal" package) — mirrors the existing headless SFTP path; happy to promote it to a dedicated public API if preferred.
- Cross-platform packaging (macOS/Linux add-launcher, PathInstaller symlink, pty4j extraction) is code-reviewed and reasoned correct but only build-tested on Windows — CI on the other platforms would be the final confirmation.
