### PR TITLE
fix: windows RDP login fail when PowerShell startup will echo some str.

### DIFF
--- a/src/main/kotlin/app/termora/plugin/internal/rdp/RDPProtocolProvider.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/rdp/RDPProtocolProvider.kt
@@ -98,7 +98,7 @@ internal class RDPProtocolProvider private constructor() : GenericProtocolProvid
 
             if (SystemInfo.isWindows) {
                 val cmd = "ConvertTo-SecureString '${password}' -AsPlainText -Force | ConvertFrom-SecureString"
-                val process = ProcessBuilder("powershell.exe", "-Command", cmd).start()
+                val process = ProcessBuilder("powershell.exe", "-NoProfile", "-Command", cmd).start()
                 if (process.waitFor() == 0) {
                     ep = String(process.inputStream.readAllBytes())
                 }


### PR DESCRIPTION
add `-NoProfile` to the PowerShell command to prevent profile loading during secure string conversion.

通过增加 -NoProfile 跳过 profile 的加载，避免各种echo带来的影响。

fix: https://github.com/TermoraDev/termora/issues/1563