### PR TITLE
fix: import host list from MobaXterm with fail on ANSI

### DIFF
--- a/src/main/java/app/termora/MyKernel32.java
+++ b/src/main/java/app/termora/MyKernel32.java
@@ -5,10 +5,12 @@ import com.sun.jna.Pointer;
 import com.sun.jna.WString;
 import com.sun.jna.win32.StdCallLibrary;
 
-interface MyKernel32 extends StdCallLibrary {
+public interface MyKernel32 extends StdCallLibrary {
 
     MyKernel32 INSTANCE = Native.load("Kernel32", MyKernel32.class);
     WString INVARIANT_LOCALE = new WString("");
+
+    int CP_ACP = 0; // System default ANSI code page
 
     int CompareStringEx(WString lpLocaleName,
                         int dwCmpFlags,
@@ -35,4 +37,6 @@ interface MyKernel32 extends StdCallLibrary {
                         Pointer.NULL,
                         0);
     }
+
+    int MultiByteToWideChar(int CodePage, int dwFlags, byte[] lpMultiByteStr, int cbMultiByte, char[] lpWideCharStr, int cchWideChar);
 }

--- a/src/main/kotlin/app/termora/tree/NewHostTree.kt
+++ b/src/main/kotlin/app/termora/tree/NewHostTree.kt
@@ -3,7 +3,6 @@ package app.termora.tree
 import app.termora.*
 import app.termora.Application.ohMyJson
 import app.termora.account.AccountManager
-import app.termora.account.Team
 import app.termora.account.TeamRole
 import app.termora.actions.AnAction
 import app.termora.actions.AnActionEvent
@@ -19,6 +18,7 @@ import app.termora.tag.TagManager
 import app.termora.tag.TagSimpleTreeCellRendererExtension
 import app.termora.transfer.TransferActionEvent
 import com.formdev.flatlaf.extras.components.FlatPopupMenu
+import com.formdev.flatlaf.util.SystemInfo
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
 import org.apache.commons.csv.CSVFormat
@@ -42,6 +42,8 @@ import java.awt.datatransfer.Transferable
 import java.awt.datatransfer.UnsupportedFlavorException
 import java.awt.event.*
 import java.io.*
+import java.nio.charset.CodingErrorAction
+import java.nio.charset.StandardCharsets
 import java.util.*
 import javax.swing.*
 import javax.swing.event.PopupMenuEvent
@@ -67,6 +69,66 @@ class NewHostTree : SimpleTree(), Disposable {
             ShowMoreInfoSimpleTreeCellRendererExtension.getInstance()
             // 标签
             TagSimpleTreeCellRendererExtension.getInstance()
+        }
+
+        private fun isUtf8(file: File): Boolean {
+            val bytes = file.readBytes()
+
+            // check UTF-8 BOM (EF BB BF)
+            if (bytes.size >= 3 &&
+                bytes[0] == 0xEF.toByte() &&
+                bytes[1] == 0xBB.toByte() &&
+                bytes[2] == 0xBF.toByte()
+            ) {
+                return true
+            }
+
+            return try {
+                StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(java.nio.ByteBuffer.wrap(bytes))
+                true
+            } catch (_: Exception) {
+                false
+            }
+        }
+
+        /**
+         * using Windows API convert ANSI -> UTF-16 -> String
+         */
+        private fun ansiToUtf8(bytes: ByteArray): String {
+            val kernel32 = MyKernel32.INSTANCE
+
+            val wideCharCount = kernel32.MultiByteToWideChar(
+                MyKernel32.CP_ACP,
+                0,  // MB_PRECOMPOSED
+                bytes,
+                bytes.size,
+                null,
+                0
+            )
+            if (wideCharCount == 0) {
+                throw RuntimeException("MultiByteToWideChar failed to calculate buffer size")
+            }
+
+            // ANSI -> UTF-16
+            val wideChars = CharArray(wideCharCount)
+            val result = kernel32.MultiByteToWideChar(
+                MyKernel32.CP_ACP,
+                0,
+                bytes,
+                bytes.size,
+                wideChars,
+                wideCharCount
+            )
+
+            if (result == 0) {
+                throw RuntimeException("MultiByteToWideChar conversion failed")
+            }
+
+            // UTF-16 to Java String
+            return String(wideChars)
         }
     }
 
@@ -906,7 +968,23 @@ class NewHostTree : SimpleTree(), Disposable {
     private fun parseFromMobaXterm(folder: HostTreeNode, file: File): List<HostTreeNode> {
         val ini = Ini()
         ini.config.isEscapeKeyOnly = true
-        ini.load(file)
+
+        if (isUtf8(file)) {
+            ini.load(file)
+        } else {
+            if (!SystemInfo.isWindows) {
+                OptionPane.showMessageDialog(
+                    owner,
+                    "Non-UTF-8 encoded MobaXterm config files are only supported on Windows. Please convert the file to UTF-8 encoding first."
+                )
+                return emptyList()
+            }
+            val bytes = file.readBytes()
+            val utf8String = ansiToUtf8(bytes)
+            StringReader(utf8String).use { reader ->
+                ini.load(reader)
+            }
+        }
 
         val bookmarks = mutableListOf<String>()
         for (key in ini.keys) {


### PR DESCRIPTION
MobaXterm 配置文件默认为 ANSI 编码，与机器环境有关。

解析时按照 unicode 解析导致了乱码。

使用 kernel32.dll 的 api 进行合理转换。

我打开了 MyKernel32 的public，若有问题我再调整

fix on [#1302](https://github.com/TermoraDev/termora/issues/1302)