### PR TITLE
Fix OpenCode TUI mouse wheel handling

### DIFF
--- a/src/main/kotlin/app/termora/terminal/panel/TerminalPanel.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalPanel.kt
@@ -211,9 +211,16 @@ class TerminalPanel(val tab: TerminalTab?, val terminal: Terminal, private val w
                 }
 
                 val unitsToScroll = e.unitsToScroll
-                if (e.isShiftDown || unitsToScroll == 0 || abs(e.preciseWheelRotation) < 0.01) {
+                if (unitsToScroll == 0 || abs(e.preciseWheelRotation) < 0.01) {
                     return
                 }
+
+                val terminalModel = terminal.getTerminalModel()
+                val mouseMode = terminalModel.getData(DataKey.MouseMode, MouseMode.MOUSE_REPORTING_NONE)
+                if (e.isShiftDown.not() && (mouseMode != MouseMode.MOUSE_REPORTING_NONE || terminalModel.isAlternateScreenBuffer())) {
+                    return
+                }
+
                 val value = scrollBar.value + unitsToScroll
                 scrollBar.value = value
                 terminal.getScrollingModel().scrollTo(value)

--- a/src/main/kotlin/app/termora/terminal/panel/TerminalPanelMouseSelectionAdapter.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalPanelMouseSelectionAdapter.kt
@@ -46,7 +46,7 @@ class TerminalPanelMouseSelectionAdapter(private val terminalPanel: TerminalPane
 
         terminalPanel.requestFocusInWindow()
 
-        if (isMouseTracking) {
+        if (isMouseTracking && e.isShiftDown.not()) {
             return
         }
 
@@ -135,8 +135,8 @@ class TerminalPanelMouseSelectionAdapter(private val terminalPanel: TerminalPane
     }
 
     override fun mouseDragged(e: MouseEvent) {
-        // 如果开启了鼠标追踪，那么就不支持选择功能了
-        if (isMouseTracking) {
+        // 如果开启了鼠标追踪，那么只有按住 Shift 时才支持本地选择功能
+        if (isMouseTracking && e.isShiftDown.not()) {
             return
         }
 

--- a/src/main/kotlin/app/termora/terminal/panel/TerminalPanelMouseTrackingAdapter.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalPanelMouseTrackingAdapter.kt
@@ -30,7 +30,7 @@ class TerminalPanelMouseTrackingAdapter(
                 || mouseMode == MouseMode.MOUSE_REPORTING_ALL_MOTION
 
     override fun mousePressed(e: MouseEvent) {
-        if (isNotMouseTracking) {
+        if (isNotMouseTracking || e.isShiftDown) {
             return
         }
         if (shouldSendMouseData) {
@@ -44,7 +44,7 @@ class TerminalPanelMouseTrackingAdapter(
 
 
     override fun mouseReleased(e: MouseEvent) {
-        if (isNotMouseTracking) {
+        if (isNotMouseTracking || e.isShiftDown) {
             return
         }
         if (shouldSendMouseData) {
@@ -57,7 +57,7 @@ class TerminalPanelMouseTrackingAdapter(
     }
 
     override fun mouseMoved(e: MouseEvent) {
-        if (mouseMode == MouseMode.MOUSE_REPORTING_ALL_MOTION) {
+        if (mouseMode == MouseMode.MOUSE_REPORTING_ALL_MOTION && e.isShiftDown.not()) {
             val p = terminalPanel.pointToPosition(e.point)
             // release - for 1000/1005/1015 mode
             mouseReport(3, p.x, p.y)
@@ -65,13 +65,26 @@ class TerminalPanelMouseTrackingAdapter(
     }
 
     override fun mouseWheelMoved(e: MouseWheelEvent) {
-        if (this.shouldSendMouseData || terminalModel.isAlternateScreenBuffer()) {
-            val unitsToScroll = e.unitsToScroll
+        if (e.isShiftDown) {
+            return
+        }
+
+        val unitsToScroll = abs(e.unitsToScroll).coerceAtLeast(1)
+        if (shouldSendMouseData) {
+            val position = terminalPanel.pointToPosition(e.point)
+            val event = AWTTerminalMouseEvent(e)
+            for (i in 0 until unitsToScroll) {
+                sendMouseEvent(position, event, TerminalMouseEventType.Pressed)
+            }
+            return
+        }
+
+        if (terminalModel.isAlternateScreenBuffer()) {
             val encode = terminal.getKeyEncoder()
                 .encode(TerminalKeyEvent(if (e.wheelRotation < 0) KeyEvent.VK_UP else KeyEvent.VK_DOWN))
             if (encode.isBlank()) return
             val bytes = encode.toByteArray(writer.getCharset())
-            for (i in 0 until abs(unitsToScroll)) {
+            for (i in 0 until unitsToScroll) {
                 writer.write(TerminalWriter.WriteRequest.fromBytes(bytes))
             }
         }


### PR DESCRIPTION
## Summary

This fixes mouse wheel handling for OpenCode TUI and other terminal applications that enable xterm mouse tracking.

Previously, Termora translated mouse wheel input to Up/Down key events in mouse tracking / alternate-screen scenarios. OpenCode TUI expects real xterm mouse wheel events, so normal mouse wheel scrolling did not work correctly.

This change:

- Sends real xterm mouse wheel events when mouse tracking is active.
- Keeps Shift + mouse wheel reserved for Termora local scrollback.
- Allows Shift + drag to perform local text selection while preserving normal mouse input for TUI applications.
- Prevents Termora local scrollback from also handling normal wheel events when mouse tracking or alternate-screen mode is active.

## Verification

Verified on Windows with OpenCode TUI:

- Normal mouse wheel scrolls OpenCode TUI messages.
- Shift + mouse wheel scrolls Termora local scrollback.
- Shift + drag performs Termora local text selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)