### PR TITLE
Fix Windows pty4j native library packaging layout

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,13 @@ fun exec(action: ExecSpec.() -> Unit) {
     providers.exec(action).result.get().assertNormalExitValue()
 }
 
+fun execIgnoreExitValue(action: ExecSpec.() -> Unit) {
+    providers.exec {
+        isIgnoreExitValue = true
+        action()
+    }.result.get()
+}
+
 allprojects {
     repositories {
         mavenCentral()
@@ -220,15 +227,15 @@ tasks.register<Copy>("copy-dependencies") {
                 FileUtils.forceMkdir(targetDir)
                 if (os.isWindows) {
                     // @formatter:off
-                    exec { commandLine("unzip","-j","-o", file.absolutePath, "com/sun/jna/win32-${arch.name}/*", "-d", targetDir.absolutePath) }
+                    execIgnoreExitValue { commandLine("unzip","-j","-o", file.absolutePath, "com/sun/jna/win32-${arch.name}/*", "-d", targetDir.absolutePath) }
                     // @formatter:on
                 } else if (os.isLinux) {
                     // @formatter:off
-                    exec { commandLine("unzip","-j","-o", file.absolutePath, "com/sun/jna/linux-${arch.name}/*", "-d", targetDir.absolutePath) }
+                    execIgnoreExitValue { commandLine("unzip","-j","-o", file.absolutePath, "com/sun/jna/linux-${arch.name}/*", "-d", targetDir.absolutePath) }
                     // @formatter:on
                 } else if (os.isMacOsX) {
                     // @formatter:off
-                    exec { commandLine("unzip","-j","-o", file.absolutePath, "com/sun/jna/darwin-${arch.name}/*", "-d", targetDir.absolutePath) }
+                    execIgnoreExitValue { commandLine("unzip","-j","-o", file.absolutePath, "com/sun/jna/darwin-${arch.name}/*", "-d", targetDir.absolutePath) }
                     // @formatter:on
                 }
 
@@ -241,14 +248,14 @@ tasks.register<Copy>("copy-dependencies") {
                 exec { commandLine("zip", "-d", file.absolutePath, "com/sun/jna/dragonflybsd-*") }
                 exec { commandLine("zip", "-d", file.absolutePath, "com/sun/jna/aix-*") }
             } else if ("${pty4j.name}-${pty4j.version}" == file.nameWithoutExtension) {
-                val osName = if (os.isWindows) "win32" else if (os.isMacOsX) "darwin" else "linux"
+                val osName = if (os.isWindows) "win" else if (os.isMacOsX) "darwin" else "linux"
                 val myArchName = if (arch.isArm) "aarch64" else "x86-64"
                 val targetDir = if (os.isMacOsX) FileUtils.getFile(dylib, pty4j.name, osName)
                 else FileUtils.getFile(dylib, pty4j.name, osName, myArchName)
                 FileUtils.forceMkdir(targetDir)
                 if (os.isWindows) {
                     // @formatter:off
-                    exec { commandLine("unzip", "-j" , "-o", file.absolutePath, "resources/*win/${myArchName}/*", "-d", targetDir.absolutePath) }
+                    exec { commandLine("unzip", "-j" , "-o", file.absolutePath, "resources/com/pty4j/native/win/${myArchName}/*", "-d", targetDir.absolutePath) }
                     // @formatter:on
                 } else if (os.isLinux) {
                     // @formatter:off
@@ -308,15 +315,15 @@ tasks.register<Copy>("copy-dependencies") {
                 val isArm = arch.isArm
                 if (os.isWindows) {
                     // @formatter:off
-                    exec { commandLine("unzip", "-j" , "-o", file.absolutePath, "com/formdev/flatlaf/natives/*windows*${if (isArm) "arm64" else "x86_64"}*", "-d", targetDir.absolutePath) }
+                    execIgnoreExitValue { commandLine("unzip", "-j" , "-o", file.absolutePath, "com/formdev/flatlaf/natives/*windows*${if (isArm) "arm64" else "x86_64"}*", "-d", targetDir.absolutePath) }
                     // @formatter:on
                 } else if (os.isLinux) {
                     // @formatter:off
-                    exec { commandLine("unzip", "-j" , "-o", file.absolutePath, "com/formdev/flatlaf/natives/*linux*${if (isArm) "arm64" else "x86_64"}*", "-d", targetDir.absolutePath) }
+                    execIgnoreExitValue { commandLine("unzip", "-j" , "-o", file.absolutePath, "com/formdev/flatlaf/natives/*linux*${if (isArm) "arm64" else "x86_64"}*", "-d", targetDir.absolutePath) }
                     // @formatter:on
                 } else if (os.isMacOsX) {
                     // @formatter:off
-                    exec { commandLine("unzip", "-j" , "-o", file.absolutePath, "com/formdev/flatlaf/natives/*macos*${if (isArm) "arm" else "x86"}*", "-d", targetDir.absolutePath) }
+                    execIgnoreExitValue { commandLine("unzip", "-j" , "-o", file.absolutePath, "com/formdev/flatlaf/natives/*macos*${if (isArm) "arm" else "x86"}*", "-d", targetDir.absolutePath) }
                     // @formatter:on
                 }
                 exec { commandLine("zip", "-d", file.absolutePath, "com/formdev/flatlaf/natives/*") }


### PR DESCRIPTION
## Summary

This fixes the Windows packaging layout for pty4j native libraries.

pty4j 0.13.10 looks up bundled Windows native libraries under:

```text
app/dylib/pty4j/win/<arch>
```

The packaging task previously placed them under:

```text
app/dylib/pty4j/win32/<arch>
```

which caused Termora to log a bundled conpty.dll lookup warning and fall back at runtime.

This change:

- Packages pty4j Windows native files under `app/dylib/pty4j/win/<arch>`.
- Uses the precise pty4j resource path when extracting native files from the jar.
- Makes optional JNA and FlatLaf native extraction tolerant when the current dependency jars do not contain the expected optional native resources, avoiding unzip no-match failures during Windows packaging.

## Verification

Verified on Windows:

- Built the Windows app image successfully.
- Confirmed `conpty.dll` is present under `app/dylib/pty4j/win/x86-64`.
- Confirmed local terminals start without the previous bundled conpty lookup warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)