### PR TITLE
feat: russian localization

### DIFF
--- a/README.ru.RU.md
+++ b/README.ru.RU.md
@@ -1,0 +1,101 @@
+<div align="center">
+<a href="./README.md">English</a> | <a href="./README.de_DE.md">Deutsch</a> | <a href="./README.zh_CN.md">简体中文</a> | <a href="./README.pt_BR.md">Português (Brasil)</a>
+</div>
+
+# Termora
+
+**Termora** — кроссплатформенный эмулятор терминала и SSH-клиент для **Windows, macOS и Linux**.
+
+<div align="center">
+  <img src="docs/readme.png" alt="Интерфейс Termora" />
+</div>
+
+Проект Termora разработан на [**Kotlin/JVM**](https://kotlinlang.org/) и частично поддерживает [**управляющие последовательности XTerm**](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html). Долгосрочная цель проекта — обеспечить **поддержку всех платформ**, включая Android, iOS и iPadOS, с помощью [**Kotlin Multiplatform**](https://kotlinlang.org/docs/multiplatform.html).
+
+
+
+## ✨ Возможности
+
+- 🧬 Кроссплатформенная работа
+- 🔐 Встроенный менеджер ключей
+- 🖼️ Перенаправление X11
+- 🧑‍💻 Интеграция с SSH-агентом
+- 💻 Отображение сведений о системе
+- 📁 Управление файлами по SFTP через графический интерфейс
+- 📊 Мониторинг загрузки видеокарт NVIDIA
+- ⚡ Быстрый запуск команд
+
+
+## 🚀 Передача файлов
+
+- Прямая передача файлов между сервером A и сервером B
+- Рекурсивная передача папок
+- До **6 одновременных задач передачи**
+
+<div align="center">
+  <img src="docs/transfer.png" alt="Передача файлов" />
+</div>
+
+
+
+## 📝 Редактирование файлов
+
+- Автоматическая отправка файла на сервер после редактирования и сохранения
+- Переименование файлов и папок
+- Быстрое удаление больших папок (поддерживается `rm -rf`)
+- Наглядное изменение прав доступа
+- Создание файлов и папок
+
+<div align="center">
+  <img src="docs/transfer-edit.png" alt="Редактирование файлов" />
+</div>
+
+## 💻 Хосты
+
+- Древовидная иерархия, аналогичная структуре папок
+- Назначение тегов отдельным хостам
+- Импорт хостов из других программ
+- Открытие хоста в инструменте передачи файлов
+
+<div align="center">
+  <img src="docs/host.png" alt="Управление хостами" />
+</div>
+
+## 🧩 Плагины
+
+- 🌍 Geo: отображение географического расположения хостов
+- 🔄 Sync: синхронизация настроек через Gist или WebDAV
+- 🗂️ WebDAV: подключение к хранилищам WebDAV
+- 📝 Editor: встроенный редактор файлов по SFTP
+- 📡 SMB: подключение к ресурсам [SMB](https://ru.wikipedia.org/wiki/Server_Message_Block)
+- ☁️ S3: подключение к объектным хранилищам S3
+- ☁️ Huawei OBS: подключение к Huawei Cloud OBS
+- ☁️ Tencent COS: подключение к Tencent Cloud COS
+- ☁️ Alibaba OSS: подключение к Alibaba Cloud OSS
+- 👉 [Посмотреть все плагины…](https://www.termora.app/plugins)
+
+
+
+
+## 📦 Загрузка
+
+- 🧾 [Последняя версия](https://github.com/TermoraDev/termora/releases/latest)
+- 🍺 **Homebrew**: `brew install --cask termora`
+- 🔨 **WinGet**: `winget install termora`
+- <img src="https://apps.microsoft.com/assets/icons/logo-16x16.png" alt="Логотип Microsoft"/> <b>Microsoft Store</b>: <a href="https://apps.microsoft.com/store/detail/9NRZBHG43SB9?cid=DevShareMCLPCS">Открыть Termora в Microsoft Store</a>
+
+
+
+## 🛠️ Разработка
+
+Для разработки рекомендуется использовать JDK [JetBrains Runtime](https://github.com/JetBrains/JetBrainsRuntime).
+
+- Локальный запуск: `./gradlew :run`
+
+
+## 📄 Лицензия
+
+Программное обеспечение распространяется по модели двойного лицензирования. Вы можете выбрать один из следующих вариантов:
+
+- **AGPL-3.0**: использование, распространение и изменение программы на условиях лицензии [AGPL-3.0](https://opensource.org/license/agpl-v3).
+- **Проприетарная лицензия**: для использования в закрытых или проприетарных проектах свяжитесь с автором, чтобы получить коммерческую лицензию.

--- a/plugins/bg/build.gradle.kts
+++ b/plugins/bg/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 
-project.version = "0.0.6"
+project.version = "0.0.7"
 
 
 

--- a/plugins/bg/src/main/kotlin/app/termora/plugins/bg/BackgroundOption.kt
+++ b/plugins/bg/src/main/kotlin/app/termora/plugins/bg/BackgroundOption.kt
@@ -95,7 +95,7 @@ class BackgroundOption : JPanel(BorderLayout()), OptionsPane.PluginOption {
             val chooser = FileChooser()
             chooser.osxAllowedFileTypes = listOf("png", "jpg", "jpeg")
             chooser.allowsMultiSelection = false
-            chooser.win32Filters.add(Pair("Image files", listOf("png", "jpg", "jpeg")))
+            chooser.win32Filters.add(Pair(I18n.getString("termora.file-chooser.image-files"), listOf("png", "jpg", "jpeg")))
             chooser.fileSelectionMode = JFileChooser.FILES_AND_DIRECTORIES
             chooser.showOpenDialog(owner).thenAccept {
                 if (it.isNotEmpty()) {

--- a/plugins/bg/src/main/resources/META-INF/plugin.xml
+++ b/plugins/bg/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,7 @@
 
     <descriptions>
         <description>Customize application background</description>
+        <description language="ru_RU">Настройка фона приложения</description>
         <description language="zh_CN">自定义应用程序背景</description>
         <description language="zh_TW">自訂應用程式背景</description>
     </descriptions>

--- a/plugins/bg/src/main/resources/i18n/messages_ru_RU.properties
+++ b/plugins/bg/src/main/resources/i18n/messages_ru_RU.properties
@@ -1,0 +1,7 @@
+termora.plugins.bg.interval=Интервал
+termora.plugins.bg.fill-mode=Режим заполнения
+termora.plugins.bg.fill-mode.stretch=Растянуть
+termora.plugins.bg.fill-mode.fit=Вписать
+termora.plugins.bg.fill-mode.center=По центру
+termora.plugins.bg.fill-mode.tile=Замостить
+termora.plugins.bg.background-image=Фоновое изображение

--- a/plugins/cos/build.gradle.kts
+++ b/plugins/cos/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
-project.version = "0.0.4"
+project.version = "0.0.5"
 
 
 

--- a/plugins/cos/src/main/kotlin/app/termora/plugins/cos/COSHostOptionsPane.kt
+++ b/plugins/cos/src/main/kotlin/app/termora/plugins/cos/COSHostOptionsPane.kt
@@ -239,13 +239,13 @@ class COSHostOptionsPane : OptionsPane() {
                 .add("${I18n.getString("termora.new-host.general.name")}:").xy(1, rows)
                 .add(nameTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("SecretId:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.secret-id")}:").xy(1, rows)
                 .add(usernameTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("SecretKey:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.secret-key")}:").xy(1, rows)
                 .add(passwordTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("Delimiter:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.delimiter")}:").xy(1, rows)
                 .add(delimiterTextField).xyw(3, rows, 5).apply { rows += step }
 
                 .add("${I18n.getString("termora.new-host.general.remark")}:").xy(1, rows)

--- a/plugins/cos/src/main/resources/META-INF/plugin.xml
+++ b/plugins/cos/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,7 @@
 
     <descriptions>
         <description>Connecting to Tencent COS</description>
+        <description language="ru_RU">Подключение к Tencent COS</description>
         <description language="zh_CN">支持连接到腾讯云对象存储</description>
         <description language="zh_TW">支援連接到騰訊雲物件存儲</description>
     </descriptions>

--- a/plugins/editor/build.gradle.kts
+++ b/plugins/editor/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 
 
-project.version = "0.0.8"
+project.version = "0.0.9"
 
 
 dependencies {

--- a/plugins/editor/src/main/resources/META-INF/plugin.xml
+++ b/plugins/editor/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,7 @@
 
     <descriptions>
         <description>Edit SFTP files using the built-in editor</description>
+        <description language="ru_RU">Редактирование файлов по SFTP во встроенном редакторе</description>
         <description language="zh_CN">使用内置编辑器编辑 SFTP 文件</description>
         <description language="zh_TW">使用內建編輯器編輯 SFTP 文件</description>
     </descriptions>

--- a/plugins/ftp/build.gradle.kts
+++ b/plugins/ftp/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
-project.version = "0.0.2"
+project.version = "0.0.3"
 
 dependencies {
     testImplementation(kotlin("test"))

--- a/plugins/ftp/src/main/kotlin/app/termora/plugins/ftp/FTPHostOptionsPane.kt
+++ b/plugins/ftp/src/main/kotlin/app/termora/plugins/ftp/FTPHostOptionsPane.kt
@@ -209,20 +209,7 @@ class FTPHostOptionsPane : OptionsPane() {
                     isSelected: Boolean,
                     cellHasFocus: Boolean
                 ): Component {
-                    var text = value?.toString() ?: ""
-                    when (value) {
-                        AuthenticationType.Password -> {
-                            text = "Password"
-                        }
-
-                        AuthenticationType.PublicKey -> {
-                            text = "Public Key"
-                        }
-
-                        AuthenticationType.KeyboardInteractive -> {
-                            text = "Keyboard Interactive"
-                        }
-                    }
+                    val text = (value as? AuthenticationType)?.getDisplayName() ?: value?.toString().orEmpty()
                     return super.getListCellRendererComponent(
                         list,
                         text,
@@ -342,6 +329,23 @@ class FTPHostOptionsPane : OptionsPane() {
 
             passiveComboBox.addItem(PassiveMode.Local)
             passiveComboBox.addItem(PassiveMode.Remote)
+            passiveComboBox.renderer = object : DefaultListCellRenderer() {
+                override fun getListCellRendererComponent(
+                    list: JList<*>?,
+                    value: Any?,
+                    index: Int,
+                    isSelected: Boolean,
+                    cellHasFocus: Boolean
+                ): Component {
+                    val key = when (value as? PassiveMode) {
+                        PassiveMode.Local -> "termora.plugins.ftp.passive.local"
+                        PassiveMode.Remote -> "termora.plugins.ftp.passive.remote"
+                        null -> null
+                    }
+                    val text = key?.let { FTPI18n.getString(it) } ?: value?.toString().orEmpty()
+                    return super.getListCellRendererComponent(list, text, index, isSelected, cellHasFocus)
+                }
+            }
 
             add(getCenterComponent(), BorderLayout.CENTER)
         }

--- a/plugins/ftp/src/main/resources/META-INF/plugin.xml
+++ b/plugins/ftp/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
 
     <descriptions>
         <description>Connecting to FTP</description>
+        <description language="ru_RU">Подключение по FTP</description>
         <description language="zh_CN">支持连接到 FTP</description>
         <description language="zh_TW">支援連接到 FTP</description>
     </descriptions>

--- a/plugins/ftp/src/main/resources/i18n/messages.properties
+++ b/plugins/ftp/src/main/resources/i18n/messages.properties
@@ -1,1 +1,3 @@
 termora.plugins.ftp.passive=Passive Mode
+termora.plugins.ftp.passive.local=Client — server
+termora.plugins.ftp.passive.remote=Server — server (FXP)

--- a/plugins/ftp/src/main/resources/i18n/messages_ru_RU.properties
+++ b/plugins/ftp/src/main/resources/i18n/messages_ru_RU.properties
@@ -1,0 +1,3 @@
+termora.plugins.ftp.passive=Пассивный режим
+termora.plugins.ftp.passive.local=Клиент — сервер
+termora.plugins.ftp.passive.remote=Сервер — сервер (FXP)

--- a/plugins/geo/build.gradle.kts
+++ b/plugins/geo/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
-project.version = "0.0.8"
+project.version = "0.0.9"
 
 dependencies {
     testImplementation(kotlin("test"))

--- a/plugins/geo/src/main/kotlin/app/termora/plugins/geo/GeoHostTreeShowMoreEnableExtension.kt
+++ b/plugins/geo/src/main/kotlin/app/termora/plugins/geo/GeoHostTreeShowMoreEnableExtension.kt
@@ -19,7 +19,7 @@ internal class GeoHostTreeShowMoreEnableExtension private constructor() : HostTr
     private val enableManager get() = EnableManager.getInstance()
 
     override fun createJCheckBoxMenuItem(tree: JTree): JCheckBoxMenuItem {
-        val item = JCheckBoxMenuItem("Geo")
+        val item = JCheckBoxMenuItem(GeoI18n.getString("termora.plugins.geo.name"))
         item.isSelected = item.isEnabled && enableManager.getFlag(KEY, true)
         item.addActionListener {
             enableManager.setFlag(KEY, item.isSelected)

--- a/plugins/geo/src/main/resources/META-INF/plugin.xml
+++ b/plugins/geo/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,7 @@
 
     <descriptions>
         <description>Display the geographical location of the host</description>
+        <description language="ru_RU">Отображение географического местоположения хоста</description>
         <description language="zh_CN">显示主机的地理位置</description>
         <description language="zh_TW">顯示主機的地理位置</description>
     </descriptions>

--- a/plugins/geo/src/main/resources/i18n/messages.properties
+++ b/plugins/geo/src/main/resources/i18n/messages.properties
@@ -1,2 +1,3 @@
+termora.plugins.geo.name=Geo
 termora.plugins.geo.first-message=The first time you use the <b>Geo</b> plugin, it will download the <b>GeoLite2.mmdb</b> database. <br/>Once the download is complete, it will display the host region information.
 termora.plugins.geo.coming-soon=Geo loading

--- a/plugins/geo/src/main/resources/i18n/messages_ru_RU.properties
+++ b/plugins/geo/src/main/resources/i18n/messages_ru_RU.properties
@@ -1,0 +1,3 @@
+termora.plugins.geo.name=Геолокация
+termora.plugins.geo.first-message=При первом использовании плагина <b>Geo</b> будет загружена база <b>GeoLite2.mmdb</b>.<br/>После загрузки рядом с хостами появится информация о регионе.
+termora.plugins.geo.coming-soon=Загрузка геоданных

--- a/plugins/migration/build.gradle.kts
+++ b/plugins/migration/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 
-project.version = "0.0.4"
+project.version = "0.0.5"
 
 
 dependencies {

--- a/plugins/migration/src/main/kotlin/app/termora/plugins/migration/MigrationApplicationRunnerExtension.kt
+++ b/plugins/migration/src/main/kotlin/app/termora/plugins/migration/MigrationApplicationRunnerExtension.kt
@@ -84,7 +84,7 @@ class MigrationApplicationRunnerExtension private constructor() : ApplicationRun
                 log.error(e.message, e)
             }
             JOptionPane.showMessageDialog(
-                null, "Unable to open database",
+                null, MigrationI18n.getString("termora.plugins.migration.open-database-failed"),
                 I18n.getString("termora.title"), JOptionPane.ERROR_MESSAGE
             )
             exitProcess(1)

--- a/plugins/migration/src/main/resources/META-INF/plugin.xml
+++ b/plugins/migration/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
 
     <descriptions>
         <description>Migrate version 1.x configuration files to 2.x</description>
+        <description language="ru_RU">Перенос файлов конфигурации версии 1.x в 2.x</description>
         <description language="zh_CN">将 1.x 版本的配置文件迁移到 2.x</description>
         <description language="zh_TW">將 1.x 版本的設定檔移轉到 2.x</description>
     </descriptions>

--- a/plugins/migration/src/main/resources/i18n/messages.properties
+++ b/plugins/migration/src/main/resources/i18n/messages.properties
@@ -7,6 +7,7 @@ termora.plugins.migration.message=<html> \
 <h3 align="center">📎 For more information, please see: <a href="https://github.com/TermoraDev/termora/issues/645">TermoraDev/termora/issues/645</a></h3> \
 </html>
 termora.plugins.migration.migrate=Migrate
+termora.plugins.migration.open-database-failed=Unable to open database
 
 # Doorman
 termora.doorman.safe=Data is encrypted

--- a/plugins/migration/src/main/resources/i18n/messages_ru_RU.properties
+++ b/plugins/migration/src/main/resources/i18n/messages_ru_RU.properties
@@ -1,18 +1,24 @@
+termora.plugins.migration.message=<html> \
+<h1 align="center">Версия 2.0 готова.</h1> \
+<br/> \
+<h3>1. Структура хранения данных обновлена. Существующие данные необходимо перенести. Просто нажмите <font color="#3573F0">«Перенести данные»</font>, чтобы завершить процесс.</h3> \
+<h3>2. <font color="#3573F0">Синхронизация</font> теперь доступна в виде плагина. При необходимости <font color="#EA33EC">установите его вручную</font> в настройках.</h3> \
+<h3>3. Функция <font color="#3573F0">шифрования данных</font> <font color="#EA33EC">удалена</font> (локальные данные теперь хранятся с базовым шифрованием). Убедитесь, что устройство находится в доверенной среде.</h3> \
+<h3 align="center">📎 Дополнительная информация: <a href="https://github.com/TermoraDev/termora/issues/645">TermoraDev/termora/issues/645</a></h3> \
+</html>
+termora.plugins.migration.migrate=Перенести данные
+termora.plugins.migration.open-database-failed=Не удалось открыть базу данных
 
 # Doorman
-termora.doorman.safe=Данные защифрованы
-termora.doorman.unlock-data=Введите пароль для разблокировки данных
-termora.doorman.verify-password=Введите пароль для проверки
+termora.doorman.safe=Данные зашифрованы
+termora.doorman.unlock-data=Введите пароль, чтобы разблокировать данные
 termora.doorman.password-wrong=Неверный пароль
-termora.doorman.password-correct=Пароль верный
-termora.doorman.unsafe=Данные не зашифрованы
-termora.doorman.lock-data=Спрашивать пароль при запуске
 termora.doorman.forget-password=Забыли пароль?
-termora.doorman.delete-data=Удалить данные и перезапустить, это приведет к потере всех данных
-termora.doorman.forget-password-message=Разблокировать данные с помощью мнемоники. Без него доступ к данным невозможен.
-termora.doorman.have-a-mnemonic=У меня есть мнемоники
-termora.doorman.dont-have-a-mnemonic=У меня нет мнемоники
-termora.doorman.mnemonic-data-corrupted=Невозможно расшифровать данные с помощью мнемоники, возможно, данные повреждены.
+termora.doorman.delete-data=Удалить каталог данных и перезапустить приложение? Все данные будут потеряны
+termora.doorman.forget-password-message=Разблокируйте данные с помощью мнемонической фразы. Без неё получить доступ к данным невозможно
+termora.doorman.have-a-mnemonic=У меня есть мнемоническая фраза
+termora.doorman.dont-have-a-mnemonic=У меня нет мнемонической фразы
+termora.doorman.mnemonic-data-corrupted=Не удалось расшифровать данные с помощью мнемонической фразы. Возможно, данные повреждены
 
-termora.doorman.mnemonic.title=Введите 12 слов мнемоники
-termora.doorman.mnemonic.incorrect=Неверные мнемоники
+termora.doorman.mnemonic.title=Введите 12 слов мнемонической фразы
+termora.doorman.mnemonic.incorrect=Неверная мнемоническая фраза

--- a/plugins/obs/build.gradle.kts
+++ b/plugins/obs/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 
-project.version = "0.0.2"
+project.version = "0.0.3"
 
 
 dependencies {

--- a/plugins/obs/src/main/kotlin/app/termora/plugins/obs/OBSHostOptionsPane.kt
+++ b/plugins/obs/src/main/kotlin/app/termora/plugins/obs/OBSHostOptionsPane.kt
@@ -270,13 +270,13 @@ class OBSHostOptionsPane : OptionsPane() {
 //                .add("Endpoint:").xy(1, rows)
 //                .add(endpointTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("SecretId:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.secret-id")}:").xy(1, rows)
                 .add(usernameTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("SecretKey:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.secret-key")}:").xy(1, rows)
                 .add(passwordTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("Delimiter:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.delimiter")}:").xy(1, rows)
                 .add(delimiterTextField).xyw(3, rows, 5).apply { rows += step }
 
                 .add("${I18n.getString("termora.new-host.general.remark")}:").xy(1, rows)

--- a/plugins/obs/src/main/resources/META-INF/plugin.xml
+++ b/plugins/obs/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
 
     <descriptions>
         <description>Connecting to Huawei OBS</description>
+        <description language="ru_RU">Подключение к Huawei OBS</description>
         <description language="zh_CN">支持连接到华为云对象存储</description>
         <description language="zh_TW">支援連接到華為雲端物件存儲</description>
     </descriptions>

--- a/plugins/oss/build.gradle.kts
+++ b/plugins/oss/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
-project.version = "0.0.3"
+project.version = "0.0.4"
 
 dependencies {
     testImplementation(kotlin("test"))

--- a/plugins/oss/src/main/kotlin/app/termora/plugins/oss/OSSHostOptionsPane.kt
+++ b/plugins/oss/src/main/kotlin/app/termora/plugins/oss/OSSHostOptionsPane.kt
@@ -270,13 +270,13 @@ class OSSHostOptionsPane : OptionsPane() {
 //                .add("Endpoint:").xy(1, rows)
 //                .add(endpointTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("SecretId:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.secret-id")}:").xy(1, rows)
                 .add(usernameTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("SecretKey:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.secret-key")}:").xy(1, rows)
                 .add(passwordTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("Delimiter:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.delimiter")}:").xy(1, rows)
                 .add(delimiterTextField).xyw(3, rows, 5).apply { rows += step }
 
                 .add("${I18n.getString("termora.new-host.general.remark")}:").xy(1, rows)

--- a/plugins/oss/src/main/resources/META-INF/plugin.xml
+++ b/plugins/oss/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
 
     <descriptions>
         <description>Connecting to Alibaba OSS</description>
+        <description language="ru_RU">Подключение к Alibaba OSS</description>
         <description language="zh_CN">支持连接到阿里云对象存储</description>
         <description language="zh_TW">支援連接到阿里雲物件存儲</description>
     </descriptions>

--- a/plugins/s3/build.gradle.kts
+++ b/plugins/s3/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 
-project.version = "0.0.6"
+project.version = "0.0.7"
 
 
 dependencies {

--- a/plugins/s3/src/main/kotlin/app/termora/plugins/s3/S3HostOptionsPane.kt
+++ b/plugins/s3/src/main/kotlin/app/termora/plugins/s3/S3HostOptionsPane.kt
@@ -222,19 +222,19 @@ class S3HostOptionsPane : OptionsPane() {
                 .add("${I18n.getString("termora.new-host.general.name")}:").xy(1, rows)
                 .add(nameTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("Endpoint:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.endpoint")}:").xy(1, rows)
                 .add(hostTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("AccessKey:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.access-key")}:").xy(1, rows)
                 .add(usernameTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("SecureKey:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.secret-key")}:").xy(1, rows)
                 .add(passwordTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("Region:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.region")}:").xy(1, rows)
                 .add(regionTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("Delimiter:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.delimiter")}:").xy(1, rows)
                 .add(delimiterTextField).xyw(3, rows, 5).apply { rows += step }
 
                 .add("${I18n.getString("termora.new-host.general.remark")}:").xy(1, rows)

--- a/plugins/s3/src/main/resources/META-INF/plugin.xml
+++ b/plugins/s3/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
 
     <descriptions>
         <description>Connecting to MinIO or AWS or other S3-compliant object storage services</description>
+        <description language="ru_RU">Подключение к MinIO, AWS и другим S3-совместимым объектным хранилищам</description>
         <description language="zh_CN">支持连接到 MinIO 或 AWS 或其他兼容 S3 协议的对象存储</description>
         <description language="zh_TW">支援連接到 MinIO 或 AWS 或其他相容 S3 協定的物件存儲</description>
     </descriptions>

--- a/plugins/serial/build.gradle.kts
+++ b/plugins/serial/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 
 
-project.version = "0.0.5"
+project.version = "0.0.6"
 
 
 dependencies {

--- a/plugins/serial/src/main/kotlin/app/termora/plugins/serial/SerialHostOptionsPane.kt
+++ b/plugins/serial/src/main/kotlin/app/termora/plugins/serial/SerialHostOptionsPane.kt
@@ -192,6 +192,26 @@ class SerialHostOptionsPane(private val accountOwner: AccountOwner) : OptionsPan
             parityComboBox.addItem(SerialCommParity.Odd)
             parityComboBox.addItem(SerialCommParity.Mark)
             parityComboBox.addItem(SerialCommParity.Space)
+            parityComboBox.renderer = object : DefaultListCellRenderer() {
+                override fun getListCellRendererComponent(
+                    list: JList<*>?,
+                    value: Any?,
+                    index: Int,
+                    isSelected: Boolean,
+                    cellHasFocus: Boolean
+                ): Component {
+                    val key = when (value) {
+                        SerialCommParity.None -> "termora.new-host.serial.parity.none"
+                        SerialCommParity.Even -> "termora.new-host.serial.parity.even"
+                        SerialCommParity.Odd -> "termora.new-host.serial.parity.odd"
+                        SerialCommParity.Mark -> "termora.new-host.serial.parity.mark"
+                        SerialCommParity.Space -> "termora.new-host.serial.parity.space"
+                        else -> null
+                    }
+                    val text = key?.let { I18n.getString(it) } ?: value?.toString().orEmpty()
+                    return super.getListCellRendererComponent(list, text, index, isSelected, cellHasFocus)
+                }
+            }
 
             stopBitsComboBox.addItem("1")
             stopBitsComboBox.addItem("1.5")
@@ -210,10 +230,14 @@ class SerialHostOptionsPane(private val accountOwner: AccountOwner) : OptionsPan
                     isSelected: Boolean,
                     cellHasFocus: Boolean
                 ): Component {
-                    val text = value?.toString() ?: StringUtils.EMPTY
+                    val text = if (value == SerialCommFlowControl.None) {
+                        I18n.getString("termora.new-host.serial.flow-control.none")
+                    } else {
+                        value?.toString()?.replace('_', '/') ?: StringUtils.EMPTY
+                    }
                     return super.getListCellRendererComponent(
                         list,
-                        text.replace('_', '/'),
+                        text,
                         index,
                         isSelected,
                         cellHasFocus

--- a/plugins/serial/src/main/resources/META-INF/plugin.xml
+++ b/plugins/serial/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,7 @@
 
     <descriptions>
         <description>Supports access to serial ports</description>
+        <description language="ru_RU">Подключение к последовательным портам</description>
         <description language="zh_CN">支持访问串口</description>
         <description language="zh_TW">支援訪問串口</description>
     </descriptions>

--- a/plugins/smb/build.gradle.kts
+++ b/plugins/smb/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
-project.version = "0.0.4"
+project.version = "0.0.5"
 
 dependencies {
     testImplementation(kotlin("test"))

--- a/plugins/smb/src/main/resources/META-INF/plugin.xml
+++ b/plugins/smb/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
 
     <descriptions>
         <description>Connecting to SMB</description>
+        <description language="ru_RU">Подключение к SMB</description>
         <description language="zh_CN">支持连接到 SMB</description>
         <description language="zh_TW">支援連接到 SMB</description>
     </descriptions>

--- a/plugins/smb/src/main/resources/i18n/messages_ru_RU.properties
+++ b/plugins/smb/src/main/resources/i18n/messages_ru_RU.properties
@@ -1,0 +1,2 @@
+termora.plugins.smb.share=Имя общего ресурса
+termora.plugins.smb.domain=Домен

--- a/plugins/sync/build.gradle.kts
+++ b/plugins/sync/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 
-project.version = "0.0.4"
+project.version = "0.0.5"
 
 
 dependencies {

--- a/plugins/sync/src/main/kotlin/app/termora/plugins/sync/CloudSyncOption.kt
+++ b/plugins/sync/src/main/kotlin/app/termora/plugins/sync/CloudSyncOption.kt
@@ -349,9 +349,9 @@ class CloudSyncOption : JPanel(BorderLayout()), OptionsPane.PluginOption {
         // 如果失败，提示错误
         if (syncResult.isFailure) {
             val exception = syncResult.exceptionOrNull()
-            var message = exception?.message ?: "Failed to sync data"
+            var message = exception?.message ?: SyncI18n.getString("termora.settings.sync.failed")
             if (exception is ResponseException) {
-                message = "Server response: ${exception.code}"
+                message = SyncI18n.getString("termora.settings.sync.server-response", exception.code)
             }
 
             if (exception != null) {

--- a/plugins/sync/src/main/resources/META-INF/plugin.xml
+++ b/plugins/sync/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,7 @@
 
     <descriptions>
         <description>Data sync to Gist or WebDAV</description>
+        <description language="ru_RU">Синхронизация данных через Gist или WebDAV</description>
         <description language="zh_CN">支持将配置同步到 Gist 或 WebDAV</description>
         <description language="zh_TW">支援將設定同步到 Gist 或 WebDAV</description>
     </descriptions>

--- a/plugins/sync/src/main/resources/i18n/messages.properties
+++ b/plugins/sync/src/main/resources/i18n/messages.properties
@@ -13,3 +13,5 @@ termora.settings.sync.webdav.help=WebDAV storage address, e.g. https://yourhost/
 termora.settings.sync.policy=Sync Policy
 termora.settings.sync.policy.manual=Manual
 termora.settings.sync.policy.on-change=On Change
+termora.settings.sync.failed=Failed to synchronize data
+termora.settings.sync.server-response=Server response: {0}

--- a/plugins/sync/src/main/resources/i18n/messages_ru_RU.properties
+++ b/plugins/sync/src/main/resources/i18n/messages_ru_RU.properties
@@ -1,0 +1,17 @@
+termora.plugins.sync.disabled-sync=Вы уже вошли в учётную запись, поэтому эта функция недоступна
+
+termora.settings.sync=Синхронизация
+termora.settings.sync.done=Данные успешно синхронизированы
+termora.settings.sync.range=Данные
+termora.settings.sync.range.keys=Мои ключи
+termora.settings.sync.range.keyword-highlights=${termora.highlight}
+termora.settings.sync.last-sync-time=Последняя синхронизация
+termora.settings.sync.gist=Gist
+termora.settings.sync.token=Токен
+termora.settings.sync.type=Тип
+termora.settings.sync.webdav.help=Адрес хранилища WebDAV, например: https://yourhost/webdav/termora.json
+termora.settings.sync.policy=Режим синхронизации
+termora.settings.sync.policy.manual=Вручную
+termora.settings.sync.policy.on-change=При изменении данных
+termora.settings.sync.failed=Не удалось синхронизировать данные
+termora.settings.sync.server-response=Ответ сервера: {0}

--- a/plugins/vnc/build.gradle.kts
+++ b/plugins/vnc/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 
-project.version = "0.0.1"
+project.version = "0.0.2"
 
 
 dependencies {

--- a/plugins/vnc/src/main/kotlin/app/termora/plugins/vnc/VNCHostOptionsPane.kt
+++ b/plugins/vnc/src/main/kotlin/app/termora/plugins/vnc/VNCHostOptionsPane.kt
@@ -188,20 +188,7 @@ internal open class VNCHostOptionsPane : OptionsPane() {
                     isSelected: Boolean,
                     cellHasFocus: Boolean
                 ): Component {
-                    var text = value?.toString() ?: ""
-                    when (value) {
-                        AuthenticationType.Password -> {
-                            text = "Password"
-                        }
-
-                        AuthenticationType.PublicKey -> {
-                            text = "Public Key"
-                        }
-
-                        AuthenticationType.KeyboardInteractive -> {
-                            text = "Keyboard Interactive"
-                        }
-                    }
+                    val text = (value as? AuthenticationType)?.getDisplayName() ?: value?.toString().orEmpty()
                     return super.getListCellRendererComponent(
                         list,
                         text,

--- a/plugins/vnc/src/main/kotlin/app/termora/plugins/vnc/VNCViewer.kt
+++ b/plugins/vnc/src/main/kotlin/app/termora/plugins/vnc/VNCViewer.kt
@@ -1,6 +1,9 @@
 package app.termora.plugins.vnc
 
 import app.termora.*
+import com.glavsoft.exceptions.AuthenticationFailedException
+import com.glavsoft.exceptions.UnsupportedProtocolVersionException
+import com.glavsoft.exceptions.UnsupportedSecurityTypeException
 import com.glavsoft.rfb.ClipboardController
 import com.glavsoft.rfb.client.KeyEventMessage
 import com.glavsoft.rfb.encoding.EncodingType
@@ -16,16 +19,18 @@ import com.glavsoft.viewer.swing.Surface
 import kotlinx.coroutines.*
 import kotlinx.coroutines.swing.Swing
 import org.apache.commons.lang3.StringUtils
-import org.apache.commons.lang3.exception.ExceptionUtils
 import java.awt.AWTEvent
 import java.awt.BorderLayout
 import java.awt.Graphics
 import java.awt.event.AWTEventListener
 import java.awt.event.ActionEvent
 import java.awt.event.MouseEvent
+import java.net.ConnectException
 import java.net.InetSocketAddress
 import java.net.Proxy
 import java.net.Socket
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import java.util.concurrent.Executors
 import javax.swing.*
 import kotlin.math.max
@@ -69,7 +74,7 @@ class VNCViewer(private val host: Host) : JPanel(BorderLayout()), Disposable {
                 withContext(Dispatchers.Swing) {
                     OptionPane.showMessageDialog(
                         owner,
-                        e.message ?: ExceptionUtils.getMessage(e),
+                        getErrorMessage(e),
                         messageType = JOptionPane.ERROR_MESSAGE
                     )
                 }
@@ -77,6 +82,31 @@ class VNCViewer(private val host: Host) : JPanel(BorderLayout()), Disposable {
         }
 
         toolkit.addAWTEventListener(toolbar, AWTEvent.MOUSE_MOTION_EVENT_MASK)
+    }
+
+    private fun getErrorMessage(exception: Exception): String {
+        val causes = generateSequence<Throwable>(exception) { it.cause }.toList()
+        return when {
+            causes.any { it is AuthenticationFailedException } ->
+                I18n.getString("termora.vnc.error.authentication-failed")
+
+            causes.any { it is UnsupportedProtocolVersionException } ->
+                I18n.getString("termora.vnc.error.unsupported-protocol")
+
+            causes.any { it is UnsupportedSecurityTypeException } ->
+                I18n.getString("termora.vnc.error.unsupported-security")
+
+            causes.any { it is SocketTimeoutException } ->
+                I18n.getString("termora.vnc.error.timeout")
+
+            causes.any { it is UnknownHostException } ->
+                I18n.getString("termora.vnc.error.unknown-host")
+
+            causes.any { it is ConnectException } ->
+                I18n.getString("termora.vnc.error.connection-failed")
+
+            else -> I18n.getString("termora.vnc.error.generic")
+        }
     }
 
     private suspend fun connect() {

--- a/plugins/vnc/src/main/resources/META-INF/plugin.xml
+++ b/plugins/vnc/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
 
     <descriptions>
         <description>VNC Viewer</description>
+        <description language="ru_RU">Просмотр удалённого рабочего стола по VNC</description>
     </descriptions>
 
     <vendor url="https://github.com/TermoraDev">TermoraDev</vendor>

--- a/plugins/webdav/build.gradle.kts
+++ b/plugins/webdav/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
-project.version = "0.0.2"
+project.version = "0.0.3"
 
 dependencies {
     testImplementation(kotlin("test"))

--- a/plugins/webdav/src/main/kotlin/app/termora/plugins/webdav/WebDAVHostOptionsPane.kt
+++ b/plugins/webdav/src/main/kotlin/app/termora/plugins/webdav/WebDAVHostOptionsPane.kt
@@ -211,7 +211,7 @@ class WebDAVHostOptionsPane : OptionsPane() {
                 .add("${I18n.getString("termora.new-host.general.name")}:").xy(1, rows)
                 .add(nameTextField).xyw(3, rows, 5).apply { rows += step }
 
-                .add("Endpoint:").xy(1, rows)
+                .add("${I18n.getString("termora.object-storage.endpoint")}:").xy(1, rows)
                 .add(endpointTextField).xyw(3, rows, 5).apply { rows += step }
 
                 .add("${I18n.getString("termora.new-host.general.username")}:").xy(1, rows)

--- a/plugins/webdav/src/main/resources/META-INF/plugin.xml
+++ b/plugins/webdav/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,7 @@
 
     <descriptions>
         <description>Connecting to WebDAV</description>
+        <description language="ru_RU">Подключение к WebDAV</description>
         <description language="zh_CN">支持连接到 WebDAV</description>
         <description language="zh_TW">支援連接到 WebDAV</description>
     </descriptions>

--- a/src/main/kotlin/app/termora/ApplicationRunner.kt
+++ b/src/main/kotlin/app/termora/ApplicationRunner.kt
@@ -351,7 +351,7 @@ class ApplicationRunner {
                 log.error(e.message, e)
             }
             JOptionPane.showMessageDialog(
-                null, "Unable to open database",
+                null, I18n.getString("termora.database.open-failed"),
                 I18n.getString("termora.title"), JOptionPane.ERROR_MESSAGE
             )
             exitProcess(1)

--- a/src/main/kotlin/app/termora/BannerPanel.kt
+++ b/src/main/kotlin/app/termora/BannerPanel.kt
@@ -18,8 +18,9 @@ class BannerPanel(fontSize: Int = 11, val beautiful: Boolean = false) : JCompone
     private val colors = mutableListOf<Color>()
 
     init {
-        font = Font("JetBrains Mono", Font.PLAIN, fontSize)
-        preferredSize = Dimension(width, getFontMetrics(font).height * banner.size)
+        font = Font(Font.MONOSPACED, Font.PLAIN, fontSize)
+        val fontMetrics = getFontMetrics(font)
+        preferredSize = Dimension(banner.maxOf(fontMetrics::stringWidth), fontMetrics.height * banner.size)
         size = preferredSize
     }
 

--- a/src/main/kotlin/app/termora/FontComboBox.kt
+++ b/src/main/kotlin/app/termora/FontComboBox.kt
@@ -29,12 +29,13 @@ class FontComboBox : FlatComboBox<String>() {
             ): Component {
                 var text = value
                 if (text is String) {
+                    val fontFamily = text
                     if (text.isBlank()) {
-                        text = "&lt;None&gt;"
+                        text = "&lt;${I18n.getString("termora.settings.terminal.fallback-font.none")}&gt;"
                     }
                     return super.getListCellRendererComponent(
                         list,
-                        "<html><font face='$text'>$text</font></html>",
+                        "<html><font face='$fontFamily'>$text</font></html>",
                         index,
                         isSelected,
                         cellHasFocus

--- a/src/main/kotlin/app/termora/Host.kt
+++ b/src/main/kotlin/app/termora/Host.kt
@@ -24,6 +24,17 @@ enum class AuthenticationType {
     KeyboardInteractive,
 }
 
+fun AuthenticationType.getDisplayName(): String {
+    val key = when (this) {
+        AuthenticationType.No -> "termora.new-host.general.authentication.none"
+        AuthenticationType.Password -> "termora.new-host.general.authentication.password"
+        AuthenticationType.PublicKey -> "termora.new-host.general.authentication.public-key"
+        AuthenticationType.SSHAgent -> "termora.new-host.general.authentication.ssh-agent"
+        AuthenticationType.KeyboardInteractive -> "termora.new-host.general.authentication.keyboard-interactive"
+    }
+    return I18n.getString(key)
+}
+
 enum class ProxyType {
     No,
     HTTP,
@@ -209,6 +220,15 @@ enum class TunnelingType {
     Local,
     Remote,
     Dynamic
+}
+
+fun TunnelingType.getDisplayName(): String {
+    val key = when (this) {
+        TunnelingType.Local -> "termora.new-host.tunneling.type.local"
+        TunnelingType.Remote -> "termora.new-host.tunneling.type.remote"
+        TunnelingType.Dynamic -> "termora.new-host.tunneling.type.dynamic"
+    }
+    return I18n.getString(key)
 }
 
 @Serializable

--- a/src/main/kotlin/app/termora/OptionPane.kt
+++ b/src/main/kotlin/app/termora/OptionPane.kt
@@ -25,7 +25,7 @@ object OptionPane {
     fun showConfirmDialog(
         parentComponent: Component?,
         message: Any,
-        title: String = UIManager.getString("OptionPane.messageDialogTitle"),
+        title: String = I18n.getString("termora.message"),
         optionType: Int = JOptionPane.YES_NO_OPTION,
         messageType: Int = JOptionPane.QUESTION_MESSAGE,
         icon: Icon? = null,
@@ -92,7 +92,7 @@ object OptionPane {
     fun showMessageDialog(
         parentComponent: Component?,
         message: String,
-        title: String = UIManager.getString("OptionPane.messageDialogTitle"),
+        title: String = I18n.getString("termora.message"),
         messageType: Int = JOptionPane.INFORMATION_MESSAGE,
         duration: Duration = Duration.ZERO,
     ) {
@@ -124,7 +124,7 @@ object OptionPane {
 
     fun showInputDialog(
         parentComponent: Component?,
-        title: String = UIManager.getString("OptionPane.messageDialogTitle"),
+        title: String = I18n.getString("termora.message"),
         value: String = StringUtils.EMPTY,
         placeholder: String = StringUtils.EMPTY,
     ): String? {

--- a/src/main/kotlin/app/termora/RequestAuthenticationDialog.kt
+++ b/src/main/kotlin/app/termora/RequestAuthenticationDialog.kt
@@ -26,7 +26,7 @@ class RequestAuthenticationDialog(owner: Window, host: Host) : DialogWrapper(own
 
     init {
         isModal = true
-        title = "SSH User Authentication"
+        title = I18n.getString("termora.ssh.user-authentication")
         controlsVisible = false
 
         init()
@@ -54,6 +54,19 @@ class RequestAuthenticationDialog(owner: Window, host: Host) : DialogWrapper(own
                     isSelected,
                     cellHasFocus
                 )
+            }
+        }
+
+        authenticationTypeComboBox.renderer = object : DefaultListCellRenderer() {
+            override fun getListCellRendererComponent(
+                list: JList<*>?,
+                value: Any?,
+                index: Int,
+                isSelected: Boolean,
+                cellHasFocus: Boolean
+            ): Component {
+                val text = (value as? AuthenticationType)?.getDisplayName() ?: value?.toString().orEmpty()
+                return super.getListCellRendererComponent(list, text, index, isSelected, cellHasFocus)
             }
         }
 

--- a/src/main/kotlin/app/termora/SettingsDialog.kt
+++ b/src/main/kotlin/app/termora/SettingsDialog.kt
@@ -16,7 +16,7 @@ internal class SettingsDialog(owner: Window) : DialogWrapper(owner) {
 
     init {
         size = Dimension(
-            UIScale.scale(UIManager.getInt("Dialog.width")),
+            UIScale.scale(maxOf(UIManager.getInt("Dialog.width"), 800)),
             UIScale.scale(UIManager.getInt("Dialog.height"))
         )
         isModal = true

--- a/src/main/kotlin/app/termora/SettingsOptionsPane.kt
+++ b/src/main/kotlin/app/termora/SettingsOptionsPane.kt
@@ -133,6 +133,23 @@ class SettingsOptionsPane : OptionsPane() {
             tabOrderComboBox.addItem(TabOrder.Hide)
             tabOrderComboBox.addItem(TabOrder.AsNeed)
             tabOrderComboBox.addItem(TabOrder.Always)
+            tabOrderComboBox.renderer = object : DefaultListCellRenderer() {
+                override fun getListCellRendererComponent(
+                    list: JList<*>?,
+                    value: Any?,
+                    index: Int,
+                    isSelected: Boolean,
+                    cellHasFocus: Boolean
+                ): Component {
+                    val text = when (value) {
+                        TabOrder.Hide -> I18n.getString("termora.settings.appearance.tab-order.hide")
+                        TabOrder.AsNeed -> I18n.getString("termora.settings.appearance.tab-order.as-needed")
+                        TabOrder.Always -> I18n.getString("termora.settings.appearance.tab-order.always")
+                        else -> value
+                    }
+                    return super.getListCellRendererComponent(list, text, index, isSelected, cellHasFocus)
+                }
+            }
             tabOrderComboBox.selectedItem = runCatching { TabOrder.valueOf(appearance.tabOrder) }
                 .getOrNull() ?: TabOrder.Hide
 
@@ -314,8 +331,8 @@ class SettingsOptionsPane : OptionsPane() {
 
         private fun showPreferredThemeContextmenu() {
             val popupMenu = FlatPopupMenu()
-            val dark = JMenu("For Dark OS")
-            val light = JMenu("For Light OS")
+            val dark = JMenu(I18n.getString("termora.settings.appearance.theme.dark-os"))
+            val light = JMenu(I18n.getString("termora.settings.appearance.theme.light-os"))
             val darkTheme = appearance.darkTheme
             val lightTheme = appearance.lightTheme
 
@@ -951,7 +968,7 @@ class SettingsOptionsPane : OptionsPane() {
                 .add(
                     createHyperlink(
                         "https://github.com/TermoraDev/termora/blob/${branch}/THIRDPARTY",
-                        "Open-source software"
+                        I18n.getString("termora.settings.about.open-source-software")
                     )
                 ).xy(3, rows).apply { rows += step }
 

--- a/src/main/kotlin/app/termora/TerminalTabbed.kt
+++ b/src/main/kotlin/app/termora/TerminalTabbed.kt
@@ -231,7 +231,7 @@ class TerminalTabbed(
         }
 
         // 克隆
-        val clone = popupMenu.add(I18n.getString("termora.copy"))
+        val clone = popupMenu.add(I18n.getString("termora.tabbed.contextmenu.clone"))
         clone.addActionListener { evt ->
             if (tab is HostTerminalTab) {
                 actionManager

--- a/src/main/kotlin/app/termora/ThemeManager.kt
+++ b/src/main/kotlin/app/termora/ThemeManager.kt
@@ -98,6 +98,7 @@ internal class ThemeManager private constructor() {
         val themeClassname = themes.getOrDefault(classname, classname)
 
         if (UIManager.getLookAndFeel().javaClass.name == themeClassname) {
+            applyLocalizedDefaults()
             return
         }
 
@@ -111,8 +112,18 @@ internal class ThemeManager private constructor() {
             FlatAnimatedLafChange.hideSnapshotWithAnimation()
         }
 
+        applyLocalizedDefaults()
+
         ExtensionManager.getInstance().getExtensions(ThemeChangeExtension::class.java)
             .forEach { it.onChanged() }
+    }
+
+    private fun applyLocalizedDefaults() {
+        UIManager.put("OptionPane.okButtonText", I18n.getString("termora.confirm"))
+        UIManager.put("OptionPane.cancelButtonText", I18n.getString("termora.cancel"))
+        UIManager.put("OptionPane.yesButtonText", I18n.getString("termora.yes"))
+        UIManager.put("OptionPane.noButtonText", I18n.getString("termora.no"))
+        UIManager.put("OptionPane.messageDialogTitle", I18n.getString("termora.message"))
     }
 
     private fun immediateChange(classname: String) {

--- a/src/main/kotlin/app/termora/account/AccountOption.kt
+++ b/src/main/kotlin/app/termora/account/AccountOption.kt
@@ -118,8 +118,8 @@ class AccountOption : JPanel(BorderLayout()), OptionsPane.Option, Disposable {
         var server = accountManager.getServer()
         var email = accountManager.getEmail()
         if (isLocally) {
-            server = I18n.getString("termora.settings.account.locally")
-            email = I18n.getString("termora.settings.account.locally")
+            server = I18n.getString("termora.settings.account.local-server")
+            email = I18n.getString("termora.settings.account.local-account")
         }
 
         val planBox = Box.createHorizontalBox()

--- a/src/main/kotlin/app/termora/account/LoginServerDialog.kt
+++ b/src/main/kotlin/app/termora/account/LoginServerDialog.kt
@@ -110,7 +110,7 @@ class LoginServerDialog(owner: Window) : DialogWrapper(owner) {
 
 
         val dialog = this
-        val newAction = object : AnAction(I18n.getString("termora.welcome.contextmenu.new")) {
+        val newAction = object : AnAction(I18n.getString("termora.settings.account.add-server")) {
             override fun actionPerformed(evt: AnActionEvent) {
                 if (serverComboBox.itemCount < 1 || serverComboBox.selectedItem == singaporeServer || serverComboBox.selectedItem == chinaServer) {
                     val c = NewServerDialog(dialog)
@@ -140,7 +140,7 @@ class LoginServerDialog(owner: Window) : DialogWrapper(owner) {
 
         fun refreshButton() {
             if (serverComboBox.selectedItem == singaporeServer || serverComboBox.selectedItem == chinaServer || serverComboBox.itemCount < 1) {
-                newAction.name = I18n.getString("termora.welcome.contextmenu.new")
+                newAction.name = I18n.getString("termora.settings.account.add-server")
             } else {
                 newAction.name = I18n.getString("termora.remove")
             }

--- a/src/main/kotlin/app/termora/findeverywhere/FindEverywhereXList.kt
+++ b/src/main/kotlin/app/termora/findeverywhere/FindEverywhereXList.kt
@@ -1,5 +1,6 @@
 package app.termora.findeverywhere
 
+import app.termora.I18n
 import com.formdev.flatlaf.ui.FlatListUI
 import org.jdesktop.swingx.JXList
 import java.awt.*
@@ -42,7 +43,7 @@ class FindEverywhereXList(private val model: DefaultListModel<FindEverywhereResu
             )
         }
         g.color = UIManager.getColor("textInactiveText")
-        val text = "Nothing found."
+        val text = I18n.getString("termora.find-everywhere.nothing-found")
         val w = g.fontMetrics.stringWidth(text)
         g.drawString(text, width / 2 - w / 2, (height * 0.25).toInt())
     }

--- a/src/main/kotlin/app/termora/highlight/ChooseColorTemplateDialog.kt
+++ b/src/main/kotlin/app/termora/highlight/ChooseColorTemplateDialog.kt
@@ -3,6 +3,7 @@ package app.termora.highlight
 import app.termora.DialogWrapper
 import app.termora.Disposable
 import app.termora.Disposer
+import app.termora.I18n
 import app.termora.TerminalFactory
 import com.formdev.flatlaf.util.SystemInfo
 import java.awt.*
@@ -52,7 +53,7 @@ class ChooseColorTemplateDialog(owner: Window, title: String) : DialogWrapper(ow
             panel.add(c)
         }
         panel.border = BorderFactory.createEmptyBorder(0, 0, 12, 0)
-        val customBtn = JButton("Custom")
+        val customBtn = JButton(I18n.getString("termora.custom"))
         customBtn.addActionListener {
             val dialog = MyColorPickerDialog(this)
             dialog.setLocationRelativeTo(this)

--- a/src/main/kotlin/app/termora/highlight/KeywordHighlightPanel.kt
+++ b/src/main/kotlin/app/termora/highlight/KeywordHighlightPanel.kt
@@ -360,7 +360,7 @@ class KeywordHighlightPanel(private val accountOwner: AccountOwner) : JPanel(Bor
             exportBtn.addActionListener {
                 val fileChooser = FileChooser()
                 fileChooser.fileSelectionMode = JFileChooser.FILES_ONLY
-                fileChooser.win32Filters.add(Pair("All files", listOf("*")))
+                fileChooser.win32Filters.add(Pair(I18n.getString("termora.file-chooser.all-files"), listOf("*")))
                 fileChooser.showSaveDialog(owner, "highlights.json").thenAccept { file ->
                     file?.outputStream()?.use {
                         val highlights = keywordHighlightManager.getKeywordHighlights(accountOwner.id)
@@ -375,7 +375,7 @@ class KeywordHighlightPanel(private val accountOwner: AccountOwner) : JPanel(Bor
                 val chooser = FileChooser()
                 chooser.osxAllowedFileTypes = listOf("json")
                 chooser.allowsMultiSelection = false
-                chooser.win32Filters.add(Pair("JSON files", listOf("json")))
+                chooser.win32Filters.add(Pair(I18n.getString("termora.file-chooser.json-files"), listOf("json")))
                 chooser.fileSelectionMode = JFileChooser.FILES_ONLY
                 chooser.showOpenDialog(owner)
                     .thenAccept { if (it.isNotEmpty()) SwingUtilities.invokeLater { importKeywordHighlights(it.first()) } }

--- a/src/main/kotlin/app/termora/highlight/KeywordHighlightView.kt
+++ b/src/main/kotlin/app/termora/highlight/KeywordHighlightView.kt
@@ -1,6 +1,7 @@
 package app.termora.highlight
 
 import app.termora.DynamicColor
+import app.termora.I18n
 import app.termora.terminal.ColorPalette
 import app.termora.terminal.TerminalColor
 import com.formdev.flatlaf.ui.FlatLineBorder
@@ -16,7 +17,7 @@ class KeywordHighlightView(
     var arc: Int = UIManager.getInt("Component.arc"),
     var fontSize: Int = 0,
 ) : JPanel() {
-    private val text = "Highlight"
+    private val text = I18n.getString("termora.highlight.preview-text")
 
     var textColor: Color? = null
     var backgroundColor: Color? = null

--- a/src/main/kotlin/app/termora/highlight/MyColorPickerDialog.kt
+++ b/src/main/kotlin/app/termora/highlight/MyColorPickerDialog.kt
@@ -1,6 +1,7 @@
 package app.termora.highlight
 
 import app.termora.DialogWrapper
+import app.termora.I18n
 import com.bric.colorpicker.ColorPicker
 import java.awt.Color
 import java.awt.Window
@@ -12,7 +13,7 @@ class MyColorPickerDialog(owner: Window) : DialogWrapper(owner) {
 
     init {
         isModal = true
-        title = "Color Picker"
+        title = I18n.getString("termora.highlight.color-picker")
         init()
         pack()
         setLocationRelativeTo(null)

--- a/src/main/kotlin/app/termora/highlight/NewKeywordHighlightDialog.kt
+++ b/src/main/kotlin/app/termora/highlight/NewKeywordHighlightDialog.kt
@@ -69,14 +69,14 @@ class NewKeywordHighlightDialog(
 
         textColorRevert.isFocusable = false
         textColorRevert.isEnabled = false
-        textColorRevert.toolTipText = "Use terminal foreground"
+        textColorRevert.toolTipText = I18n.getString("termora.highlight.use-terminal-foreground")
         textColorRevert.putClientProperty(
             FlatClientProperties.BUTTON_TYPE,
             FlatClientProperties.BUTTON_TYPE_TOOLBAR_BUTTON
         )
         backgroundColorRevert.isFocusable = false
         backgroundColorRevert.isEnabled = false
-        backgroundColorRevert.toolTipText = "Use terminal background"
+        backgroundColorRevert.toolTipText = I18n.getString("termora.highlight.use-terminal-background")
         backgroundColorRevert.putClientProperty(
             FlatClientProperties.BUTTON_TYPE,
             FlatClientProperties.BUTTON_TYPE_TOOLBAR_BUTTON

--- a/src/main/kotlin/app/termora/keymap/KeymapPanel.kt
+++ b/src/main/kotlin/app/termora/keymap/KeymapPanel.kt
@@ -171,12 +171,12 @@ class KeymapPanel : JPanel(BorderLayout()) {
 
 
     private fun copyKeymap(keymap: Keymap) {
-        var name = keymap.name + " Copy"
+        var name = I18n.getString("termora.settings.keymap.copy-name", keymap.name)
         for (i in 0 until Int.MAX_VALUE) {
             if (keymapManager.getKeymap(name) == null) {
                 break
             }
-            name = keymap.name + " Copy(${i + 1})"
+            name = I18n.getString("termora.settings.keymap.copy-name-indexed", keymap.name, i + 1)
         }
 
         keymapManager.addKeymap(cloneKeymap(name, keymap))

--- a/src/main/kotlin/app/termora/keymgr/KeyManagerPanel.kt
+++ b/src/main/kotlin/app/termora/keymgr/KeyManagerPanel.kt
@@ -181,7 +181,7 @@ class KeyManagerPanel(private val accountOwner: AccountOwner) : JPanel(BorderLay
 
                 val fileChooser = FileChooser()
                 fileChooser.fileSelectionMode = JFileChooser.FILES_ONLY
-                fileChooser.win32Filters.add(Pair("Zip files", listOf("zip")))
+                fileChooser.win32Filters.add(Pair(I18n.getString("termora.file-chooser.zip-files"), listOf("zip")))
                 fileChooser.showSaveDialog(SwingUtilities.getWindowAncestor(this@KeyManagerPanel), "key-export.zip")
                     .thenAccept { file ->
                         if (file != null) {
@@ -385,7 +385,7 @@ class KeyManagerPanel(private val accountOwner: AccountOwner) : JPanel(BorderLay
                 .add(nameTextField).xy(3, rows).apply { rows += step }
                 .add("${I18n.getString("termora.keymgr.table.remark")}:").xy(1, rows)
                 .add(remarkTextField).xy(3, rows).apply { rows += step }
-                .add("PublicKey:").xy(1, rows)
+                .add("${I18n.getString("termora.new-host.general.authentication.public-key")}:").xy(1, rows)
                 .add(JScrollPane(publicKeyTextArea).apply { border = FlatTextBorder() }).xy(3, rows)
                 .apply { rows += step }
                 .add(savePublicKeyBtn).xyw(1, rows, 3, "right, fill").apply { rows += step }
@@ -397,7 +397,7 @@ class KeyManagerPanel(private val accountOwner: AccountOwner) : JPanel(BorderLay
             savePublicKeyBtn.addActionListener {
                 val fileChooser = FileChooser()
                 fileChooser.fileSelectionMode = JFileChooser.FILES_ONLY
-                fileChooser.win32Filters.add(Pair("All Files", listOf("*")))
+                fileChooser.win32Filters.add(Pair(I18n.getString("termora.file-chooser.all-files"), listOf("*")))
                 fileChooser.showSaveDialog(this, "${nameTextField.text}.pub").thenAccept { file ->
                     file?.outputStream()?.use {
                         IOUtils.write(publicKeyTextArea.text, it, StandardCharsets.UTF_8)
@@ -630,7 +630,14 @@ class KeyManagerPanel(private val accountOwner: AccountOwner) : JPanel(BorderLay
                     ) ?: String()
                 }
                 val keyPair = provider.loadKeys(null).firstOrNull()
-                    ?: throw IllegalStateException("Failed to load the key file")
+                    ?: run {
+                        OptionPane.showMessageDialog(
+                            this,
+                            I18n.getString("termora.keymgr.import.load-failed"),
+                            messageType = JOptionPane.ERROR_MESSAGE
+                        )
+                        return
+                    }
                 val keyType = KeyUtils.getKeyType(keyPair)
                 if (keyType != KeyPairProvider.SSH_RSA
                     && keyType != KeyPairProvider.SSH_ED25519
@@ -638,7 +645,12 @@ class KeyManagerPanel(private val accountOwner: AccountOwner) : JPanel(BorderLay
                     && keyType != KeyPairProvider.ECDSA_SHA2_NISTP384
                     && keyType != KeyPairProvider.ECDSA_SHA2_NISTP521
                 ) {
-                    throw UnsupportedOperationException("Key type:${keyType}. Only RSA/ED25519/ECDSA keys are supported.")
+                    OptionPane.showMessageDialog(
+                        this,
+                        I18n.getString("termora.keymgr.import.unsupported-key-type", keyType),
+                        messageType = JOptionPane.ERROR_MESSAGE
+                    )
+                    return
                 }
 
                 nameTextField.text = StringUtils.defaultIfBlank(nameTextField.text, file.name)
@@ -668,10 +680,10 @@ class KeyManagerPanel(private val accountOwner: AccountOwner) : JPanel(BorderLay
                     id = randomUUID(),
                     length = lengthComboBox.selectedItem as Int,
                 )
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 OptionPane.showMessageDialog(
                     this,
-                    e.message ?: e.toString(),
+                    I18n.getString("termora.keymgr.import.error"),
                     messageType = JOptionPane.ERROR_MESSAGE
                 )
             }

--- a/src/main/kotlin/app/termora/keymgr/SSHCopyIdDialog.kt
+++ b/src/main/kotlin/app/termora/keymgr/SSHCopyIdDialog.kt
@@ -49,7 +49,7 @@ class SSHCopyIdDialog(
     init {
         size = Dimension(UIManager.getInt("Dialog.width") - 100, UIManager.getInt("Dialog.height") - 100)
         isModal = true
-        title = "SSH Copy ID"
+        title = I18n.getString("termora.keymgr.ssh-copy-id.title")
         setLocationRelativeTo(null)
 
         Disposer.register(disposable, object : Disposable {

--- a/src/main/kotlin/app/termora/plugin/PluginDescriptor.kt
+++ b/src/main/kotlin/app/termora/plugin/PluginDescriptor.kt
@@ -21,7 +21,20 @@ open class PluginDescriptor(
         val defaultIcon: Icon = ScaleIcon(Icons.plugin, 32)
     }
 
+    val name: String get() = getBestName()
     val description: String get() = getBestDescription()
+
+    private fun getBestName(): String {
+        val language = I18n.containsLanguage(Locale.getDefault()) ?: "en_US"
+        if (language == "ru_RU") {
+            val key = "termora.settings.plugin.name.$id"
+            val localizedName = I18n.getString(key)
+            if (localizedName != key) {
+                return localizedName
+            }
+        }
+        return plugin.getName()
+    }
 
     private fun getBestDescription(): String {
         if (descriptions.isEmpty()) return plugin.getName()

--- a/src/main/kotlin/app/termora/plugin/internal/BasicProxyOption.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/BasicProxyOption.kt
@@ -36,6 +36,24 @@ class BasicProxyOption(
 
     private fun initView() {
         add(getCenterComponent(), BorderLayout.CENTER)
+        proxyTypeComboBox.renderer = object : DefaultListCellRenderer() {
+            override fun getListCellRendererComponent(
+                list: JList<*>?,
+                value: Any?,
+                index: Int,
+                isSelected: Boolean,
+                cellHasFocus: Boolean
+            ): Component {
+                val text = if (value == ProxyType.No) I18n.getString("termora.no") else value?.toString().orEmpty()
+                return super.getListCellRendererComponent(
+                    list,
+                    text,
+                    index,
+                    isSelected,
+                    cellHasFocus
+                )
+            }
+        }
         proxyAuthenticationTypeComboBox.renderer = object : DefaultListCellRenderer() {
             override fun getListCellRendererComponent(
                 list: JList<*>?,
@@ -44,20 +62,7 @@ class BasicProxyOption(
                 isSelected: Boolean,
                 cellHasFocus: Boolean
             ): Component {
-                var text = value?.toString() ?: ""
-                when (value) {
-                    AuthenticationType.Password -> {
-                        text = "Password"
-                    }
-
-                    AuthenticationType.PublicKey -> {
-                        text = "Public Key"
-                    }
-
-                    AuthenticationType.KeyboardInteractive -> {
-                        text = "Keyboard Interactive"
-                    }
-                }
+                val text = (value as? AuthenticationType)?.getDisplayName() ?: value?.toString().orEmpty()
                 return super.getListCellRendererComponent(
                     list,
                     text,

--- a/src/main/kotlin/app/termora/plugin/internal/BasicTerminalOption.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/BasicTerminalOption.kt
@@ -96,7 +96,7 @@ open class BasicTerminalOption() : JPanel(BorderLayout()), Option {
             val highlights = KeywordHighlightManager.getInstance()
                 .getKeywordHighlights(accountOwner.id)
                 .filter { it.type == KeywordHighlightType.Set }
-            highlightSetComboBox.addItem(KeywordHighlight(id = "-1", keyword = "None"))
+            highlightSetComboBox.addItem(KeywordHighlight(id = "-1", keyword = I18n.getString("termora.no")))
             val defaultHighlight = KeywordHighlight(id = "0", keyword = I18n.getString("termora.highlight.default-set"))
             highlightSetComboBox.addItem(defaultHighlight)
             for (highlight in highlights) {

--- a/src/main/kotlin/app/termora/plugin/internal/plugin/MarketplacePanel.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/plugin/MarketplacePanel.kt
@@ -122,13 +122,13 @@ class MarketplacePanel : JPanel(BorderLayout()), Disposable {
                             }
                             cardLayout.show(cardPanel, PanelState.Plugins.name)
                         } else {
-                            failedLabel.text = "No plugins found"
+                            failedLabel.text = I18n.getString("termora.settings.plugin.marketplace.empty")
                             cardLayout.show(cardPanel, PanelState.FetchFailed.name)
                         }
                     }
                 } catch (_: Exception) {
                     withContext(Dispatchers.Swing) {
-                        failedLabel.text = "Failed to fetch the plugins"
+                        failedLabel.text = I18n.getString("termora.settings.plugin.marketplace.fetch-failed")
                         cardLayout.show(cardPanel, PanelState.FetchFailed.name)
                     }
                 } finally {

--- a/src/main/kotlin/app/termora/plugin/internal/plugin/PluginOption.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/plugin/PluginOption.kt
@@ -124,7 +124,7 @@ class PluginOption : JPanel(BorderLayout()), OptionsPane.Option, Disposable, Acc
             val chooser = FileChooser()
             chooser.osxAllowedFileTypes = listOf("zip")
             chooser.allowsMultiSelection = false
-            chooser.win32Filters.add(Pair("Zip files", listOf("zip")))
+            chooser.win32Filters.add(Pair(I18n.getString("termora.file-chooser.zip-files"), listOf("zip")))
             chooser.fileSelectionMode = JFileChooser.FILES_ONLY
             chooser.showOpenDialog(owner).thenAccept { if (it.isNotEmpty()) installPluginFromDisk(it.first()) }
         }
@@ -171,7 +171,7 @@ class PluginOption : JPanel(BorderLayout()), OptionsPane.Option, Disposable, Acc
     private fun installPlugin(folder: File, pluginDescriptor: PluginDescriptor) {
         if (OptionPane.showConfirmDialog(
                 owner,
-                I18n.getString("termora.settings.plugin.install-from-disk-warning", pluginDescriptor.plugin.getName()),
+                I18n.getString("termora.settings.plugin.install-from-disk-warning", pluginDescriptor.name),
                 optionType = JOptionPane.OK_CANCEL_OPTION,
                 messageType = JOptionPane.WARNING_MESSAGE,
                 options = arrayOf(I18n.getString("termora.settings.plugin.install"), I18n.getString("termora.cancel")),

--- a/src/main/kotlin/app/termora/plugin/internal/plugin/PluginPanel.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/plugin/PluginPanel.kt
@@ -57,7 +57,7 @@ class PluginPanel(val descriptor: PluginPluginDescriptor) : JPanel(), Disposable
         this.add(Box.createHorizontalStrut(8))
 
         val infoBox = Box.createVerticalBox()
-        infoBox.add(JLabel("<html><b>${descriptor.plugin.getName()}</b>&nbsp;&nbsp;${descriptor.version}</html>"))
+        infoBox.add(JLabel("<html><b>${descriptor.name}</b>&nbsp;&nbsp;${descriptor.version}</html>"))
         infoBox.add(Box.createVerticalStrut(4))
         val descriptionLabel = JXLabel(descriptor.description)
             .apply { foreground = DynamicColor("textInactiveText") }
@@ -160,7 +160,7 @@ class PluginPanel(val descriptor: PluginPluginDescriptor) : JPanel(), Disposable
         if (path.exists().not() || path.isDirectory.not()) return
 
         if (OptionPane.showConfirmDialog(
-                owner, I18n.getString("termora.settings.plugin.uninstall-confirm", descriptor.plugin.getName()),
+                owner, I18n.getString("termora.settings.plugin.uninstall-confirm", descriptor.name),
                 optionType = JOptionPane.OK_CANCEL_OPTION,
                 options = arrayOf(
                     I18n.getString("termora.settings.plugin.uninstall"),
@@ -344,7 +344,7 @@ class PluginPanel(val descriptor: PluginPluginDescriptor) : JPanel(), Disposable
                     owner,
                     I18n.getString(
                         "termora.settings.plugin.install-from-disk-warning",
-                        descriptor.plugin.getName()
+                        descriptor.name
                     ),
                     optionType = JOptionPane.OK_CANCEL_OPTION,
                     messageType = JOptionPane.WARNING_MESSAGE,

--- a/src/main/kotlin/app/termora/plugin/internal/plugin/PluginRepositoryDialog.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/plugin/PluginRepositoryDialog.kt
@@ -23,7 +23,7 @@ internal class PluginRepositoryDialog(owner: Window) : DialogWrapper(owner) {
         size = Dimension(UIManager.getInt("Dialog.width") - 200, UIManager.getInt("Dialog.height") - 150)
         isModal = true
         isResizable = false
-        title = "Custom Plugin Repository"
+        title = I18n.getString("termora.settings.plugin.repository.title")
         list.fixedCellHeight = UIManager.getInt("Tree.rowHeight")
         for (url in PluginRepositoryManager.getInstance().getRepositories()) {
             model.addElement(url)
@@ -53,7 +53,10 @@ internal class PluginRepositoryDialog(owner: Window) : DialogWrapper(owner) {
 
         addBtn.addActionListener(object : AbstractAction() {
             override fun actionPerformed(e: ActionEvent) {
-                val text = OptionPane.showInputDialog(dialog)
+                val text = OptionPane.showInputDialog(
+                    dialog,
+                    title = I18n.getString("termora.settings.plugin.repository.add")
+                )
                 if (text.isNullOrBlank()) return
                 if ((text.startsWith("http://") || text.startsWith("https://")).not()) {
                     return

--- a/src/main/kotlin/app/termora/plugin/internal/rdp/RDPHostOptionsPane.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/rdp/RDPHostOptionsPane.kt
@@ -183,20 +183,7 @@ internal open class RDPHostOptionsPane(private val accountOwner: AccountOwner) :
                     isSelected: Boolean,
                     cellHasFocus: Boolean
                 ): Component {
-                    var text = value?.toString() ?: ""
-                    when (value) {
-                        AuthenticationType.Password -> {
-                            text = "Password"
-                        }
-
-                        AuthenticationType.PublicKey -> {
-                            text = "Public Key"
-                        }
-
-                        AuthenticationType.KeyboardInteractive -> {
-                            text = "Keyboard Interactive"
-                        }
-                    }
+                    val text = (value as? AuthenticationType)?.getDisplayName() ?: value?.toString().orEmpty()
                     return super.getListCellRendererComponent(
                         list,
                         text,

--- a/src/main/kotlin/app/termora/plugin/internal/ssh/SSHHostOptionsPane.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/ssh/SSHHostOptionsPane.kt
@@ -355,20 +355,7 @@ internal class SSHHostOptionsPane(private val accountOwner: AccountOwner) : Opti
                     isSelected: Boolean,
                     cellHasFocus: Boolean
                 ): Component {
-                    var text = value?.toString() ?: ""
-                    when (value) {
-                        AuthenticationType.Password -> {
-                            text = "Password"
-                        }
-
-                        AuthenticationType.PublicKey -> {
-                            text = "Public Key"
-                        }
-
-                        AuthenticationType.KeyboardInteractive -> {
-                            text = "Keyboard Interactive"
-                        }
-                    }
+                    val text = (value as? AuthenticationType)?.getDisplayName() ?: value?.toString().orEmpty()
                     return super.getListCellRendererComponent(
                         list,
                         text,
@@ -605,8 +592,8 @@ internal class SSHHostOptionsPane(private val accountOwner: AccountOwner) : Opti
 
     private inner class TunnelingOption : JPanel(BorderLayout()), Option {
         val tunnelings = mutableListOf<Tunneling>()
-        val x11ForwardingCheckBox = JCheckBox("X DISPLAY:")
-        val forwardAgentCheckBox = JCheckBox("Enable ForwardAgent")
+        val x11ForwardingCheckBox = JCheckBox("${I18n.getString("termora.new-host.tunneling.x-display")}:")
+        val forwardAgentCheckBox = JCheckBox(I18n.getString("termora.new-host.tunneling.agent.enable"))
         val x11ServerTextField = OutlineTextField(255)
 
         private val model = object : DefaultTableModel() {
@@ -628,7 +615,7 @@ internal class SSHHostOptionsPane(private val accountOwner: AccountOwner) : Opti
                 val tunneling = tunnelings[row]
                 return when (column) {
                     0 -> tunneling.name
-                    1 -> tunneling.type
+                    1 -> tunneling.type.getDisplayName()
                     2 -> "${tunneling.sourceHost}:${tunneling.sourcePort}"
                     3 -> "${tunneling.destinationHost}:${tunneling.destinationPort}"
                     else -> super.getValueAt(row, column)
@@ -691,7 +678,7 @@ internal class SSHHostOptionsPane(private val accountOwner: AccountOwner) : Opti
 
             val x11Forwarding = Box.createHorizontalBox()
             x11Forwarding.border = BorderFactory.createCompoundBorder(
-                BorderFactory.createTitledBorder("X11 Forwarding"),
+                BorderFactory.createTitledBorder(I18n.getString("termora.new-host.tunneling.x11")),
                 BorderFactory.createEmptyBorder(4, 4, 4, 4)
             )
             x11Forwarding.add(x11ForwardingCheckBox)
@@ -699,7 +686,7 @@ internal class SSHHostOptionsPane(private val accountOwner: AccountOwner) : Opti
 
             val forwardAgent = Box.createHorizontalBox()
             forwardAgent.border = BorderFactory.createCompoundBorder(
-                BorderFactory.createTitledBorder("Agent Forwarding"),
+                BorderFactory.createTitledBorder(I18n.getString("termora.new-host.tunneling.agent")),
                 BorderFactory.createEmptyBorder(4, 4, 4, 4)
             )
             forwardAgent.add(forwardAgentCheckBox)
@@ -707,7 +694,7 @@ internal class SSHHostOptionsPane(private val accountOwner: AccountOwner) : Opti
             x11ServerTextField.isEnabled = x11ForwardingCheckBox.isSelected
 
             val panel = JPanel(BorderLayout())
-            panel.add(JLabel("TCP/IP Forwarding:"), BorderLayout.NORTH)
+            panel.add(JLabel("${I18n.getString("termora.new-host.tunneling.tcp")}:"), BorderLayout.NORTH)
             panel.add(scrollPane, BorderLayout.CENTER)
             panel.add(box, BorderLayout.SOUTH)
             panel.border = BorderFactory.createEmptyBorder(0, 0, 8, 0)
@@ -817,6 +804,24 @@ internal class SSHHostOptionsPane(private val accountOwner: AccountOwner) : Opti
                 typeComboBox.addItem(TunnelingType.Local)
                 typeComboBox.addItem(TunnelingType.Remote)
                 typeComboBox.addItem(TunnelingType.Dynamic)
+                typeComboBox.renderer = object : DefaultListCellRenderer() {
+                    override fun getListCellRendererComponent(
+                        list: JList<*>?,
+                        value: Any?,
+                        index: Int,
+                        isSelected: Boolean,
+                        cellHasFocus: Boolean
+                    ): Component {
+                        val text = (value as? TunnelingType)?.getDisplayName() ?: value?.toString().orEmpty()
+                        return super.getListCellRendererComponent(
+                            list,
+                            text,
+                            index,
+                            isSelected,
+                            cellHasFocus
+                        )
+                    }
+                }
 
                 localHostTextField.text = "127.0.0.1"
                 localPortSpinner.value = 1080

--- a/src/main/kotlin/app/termora/plugin/internal/ssh/SshClients.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/ssh/SshClients.kt
@@ -542,7 +542,7 @@ object SshClients {
             return OptionPane.showConfirmDialog(
                 owner,
                 panel,
-                "SSH Security Warning",
+                I18n.getString("termora.host.modified-server-key.warning"),
                 messageType = JOptionPane.WARNING_MESSAGE,
                 optionType = JOptionPane.OK_CANCEL_OPTION
             )

--- a/src/main/kotlin/app/termora/plugin/internal/telnet/TelnetHostOptionsPane.kt
+++ b/src/main/kotlin/app/termora/plugin/internal/telnet/TelnetHostOptionsPane.kt
@@ -272,8 +272,8 @@ class TelnetHostOptionsPane(private val accountOwner: AccountOwner) : OptionsPan
 
         override fun toString(): String {
             return when (this) {
-                Backspace -> "ASCII Backspace (0x08)"
-                Delete -> "ASCII Delete (0x7F)"
+                Backspace -> "ASCII BS (0x08)"
+                Delete -> "ASCII DEL (0x7F)"
                 VT220 -> "VT220 Delete (ESC[3~)"
             }
         }

--- a/src/main/kotlin/app/termora/snippet/SnippetBannerPanel.kt
+++ b/src/main/kotlin/app/termora/snippet/SnippetBannerPanel.kt
@@ -15,8 +15,9 @@ class SnippetBannerPanel(fontSize: Int = 12) : JComponent() {
 """.trimIndent().lines()
 
     init {
-        font = Font("JetBrains Mono", Font.PLAIN, fontSize)
-        preferredSize = Dimension(width, getFontMetrics(font).height * banner.size)
+        font = Font(Font.MONOSPACED, Font.PLAIN, fontSize)
+        val fontMetrics = getFontMetrics(font)
+        preferredSize = Dimension(banner.maxOf(fontMetrics::stringWidth), fontMetrics.height * banner.size)
         size = preferredSize
     }
 

--- a/src/main/kotlin/app/termora/terminal/TerminalFontResolver.kt
+++ b/src/main/kotlin/app/termora/terminal/TerminalFontResolver.kt
@@ -1,0 +1,36 @@
+package app.termora.terminal
+
+import java.awt.Font
+
+object TerminalFontResolver {
+    private val preferredFallbackFamilies = listOf(
+        "Cascadia Mono",
+        "Cascadia Code",
+        "Consolas",
+        "Lucida Console",
+        Font.MONOSPACED,
+    )
+
+    fun resolve(fontName: String, style: Int, size: Int): Font {
+        val requestedFont = Font(fontName, style, size)
+        return if (isExactFamily(requestedFont, fontName)) {
+            requestedFont
+        } else {
+            fallback(style, size)
+        }
+    }
+
+    fun fallback(style: Int, size: Int): Font {
+        for (family in preferredFallbackFamilies) {
+            val font = Font(family, style, size)
+            if (isExactFamily(font, family)) {
+                return font
+            }
+        }
+        return Font(Font.MONOSPACED, style, size)
+    }
+
+    private fun isExactFamily(font: Font, requestedFamily: String): Boolean {
+        return font.family.equals(requestedFamily, ignoreCase = true)
+    }
+}

--- a/src/main/kotlin/app/termora/terminal/panel/TerminalDisplay.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/TerminalDisplay.kt
@@ -44,7 +44,7 @@ class TerminalDisplay(
     private val toaster = Toaster()
 
     private var font = getTerminalFont()
-    private var monospacedFont = Font(Font.MONOSPACED, font.style, font.size)
+    private var monospacedFont = TerminalFontResolver.fallback(font.style, font.size)
     private var boldFont = font.deriveFont(Font.BOLD)
     private var italicFont = font.deriveFont(Font.ITALIC)
     private var boldItalicFont = font.deriveFont(Font.ITALIC or Font.BOLD)
@@ -190,22 +190,28 @@ class TerminalDisplay(
     }
 
     private fun checkFont() {
-        val terminal = DatabaseManager.getInstance().terminal
+        val expectedFont = getTerminalFont()
+        val expectedFallbackFont = getFallbackTerminalFont()
+        var changed = false
 
-        if ((terminal.fallbackFont.isNotBlank() && fallbackFont == null) ||
-            (terminal.fallbackFont.isBlank() && fallbackFont != null) ||
-            (terminal.fallbackFont != fallbackFont?.family) ||
-            (font.size != terminal.fontSize)
+        if (fallbackFont?.fontName != expectedFallbackFont?.fontName ||
+            fallbackFont?.size != expectedFallbackFont?.size
         ) {
-            fallbackFont = getFallbackTerminalFont()
+            fallbackFont = expectedFallbackFont
+            changed = true
         }
 
-        if (font.family != terminal.font || font.size != terminal.fontSize) {
-            font = getTerminalFont()
+        if (font.fontName != expectedFont.fontName || font.size != expectedFont.size) {
+            font = expectedFont
             boldFont = font.deriveFont(Font.BOLD)
             italicFont = font.deriveFont(Font.ITALIC)
             boldItalicFont = font.deriveFont(Font.ITALIC or Font.BOLD)
-            monospacedFont = Font(Font.MONOSPACED, font.style, font.size)
+            monospacedFont = TerminalFontResolver.fallback(font.style, font.size)
+            changed = true
+        }
+
+        if (changed) {
+            lru.clear()
         }
     }
 
@@ -502,7 +508,7 @@ class TerminalDisplay(
 
     private fun getTerminalFont(): Font {
         val terminal = DatabaseManager.getInstance().terminal
-        return Font(terminal.font, Font.PLAIN, terminal.fontSize)
+        return resolveFont(terminal.font, terminal.fontSize)
     }
 
     private fun getFallbackTerminalFont(): Font? {
@@ -510,8 +516,12 @@ class TerminalDisplay(
         return if (terminal.fallbackFont.isBlank()) {
             null
         } else {
-            Font(terminal.fallbackFont, Font.PLAIN, terminal.fontSize)
+            resolveFont(terminal.fallbackFont, terminal.fontSize)
         }
+    }
+
+    private fun resolveFont(fontName: String, fontSize: Int): Font {
+        return TerminalFontResolver.resolve(fontName, Font.PLAIN, fontSize)
     }
 
     fun toast(text: String, duration: Duration) {

--- a/src/main/kotlin/app/termora/terminal/panel/vw/NvidiaSMIVisualWindow.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/vw/NvidiaSMIVisualWindow.kt
@@ -39,7 +39,7 @@ internal class NvidiaSMIVisualWindow(tab: SSHTerminalTab, visualWindowManager: V
     private val busyLabel = JXBusyLabel()
     private val errorPanel = FormBuilder.create().layout(FormLayout("pref:grow", "20dlu, pref, 5dlu, pref"))
         .add(JLabel(FlatSVGIcon(Icons.warningDialog.name, 60, 60))).xy(1, 2, "center, fill")
-        .add(JLabel("Not supported")).xy(1, 4, "center, fill")
+        .add(JLabel(I18n.getString("termora.not-supported"))).xy(1, 4, "center, fill")
         .build()
     private val loadingPanel = FormBuilder.create().layout(FormLayout("pref:grow", "20dlu, pref"))
         .add(busyLabel).xy(1, 2, "center, fill")
@@ -177,13 +177,13 @@ internal class NvidiaSMIVisualWindow(tab: SSHTerminalTab, visualWindowManager: V
                         BorderFactory.createEmptyBorder(4, 4, 4, 4),
                     )
                 )
-                .add("GPU: ").xy(1, rows)
+                .add("${I18n.getString("termora.visual-window.nvidia-smi.gpu")}: ").xy(1, rows)
                 .add(gpuProgressBar).xy(3, rows).apply { rows += step }
-                .add("Temp: ").xy(1, rows)
+                .add("${I18n.getString("termora.visual-window.nvidia-smi.temperature")}: ").xy(1, rows)
                 .add(tempProgressBar).xy(3, rows).apply { rows += step }
-                .add("Mem: ").xy(1, rows)
+                .add("${I18n.getString("termora.visual-window.nvidia-smi.memory")}: ").xy(1, rows)
                 .add(memProgressBar).xy(3, rows).apply { rows += step }
-                .add("Power: ").xy(1, rows)
+                .add("${I18n.getString("termora.visual-window.nvidia-smi.power")}: ").xy(1, rows)
                 .add(powerProgressBar).xy(3, rows).apply { rows += step }
                 .build()
             add(p, BorderLayout.CENTER)
@@ -241,11 +241,11 @@ internal class NvidiaSMIVisualWindow(tab: SSHTerminalTab, visualWindowManager: V
                         )
                     )
                     .add(Box.createHorizontalGlue()).xy(1, 1)
-                    .add("Driver: ").xy(2, 1)
+                    .add("${I18n.getString("termora.visual-window.nvidia-smi.driver")}: ").xy(2, 1)
                     .add(driverVersionLabel).xy(3, 1)
                     .add("CUDA: ").xy(5, 1)
                     .add(cudaVersionLabel).xy(6, 1)
-                    .add("GPUS: ").xy(8, 1)
+                    .add("${I18n.getString("termora.visual-window.nvidia-smi.gpus")}: ").xy(8, 1)
                     .add(gpusLabel).xy(9, 1)
                     .add(Box.createHorizontalGlue()).xy(10, 1)
                     .build(), BorderLayout.NORTH

--- a/src/main/kotlin/app/termora/terminal/panel/vw/SystemInformationVisualWindow.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/vw/SystemInformationVisualWindow.kt
@@ -83,7 +83,7 @@ internal class SystemInformationVisualWindow(tab: SSHTerminalTab, visualWindowMa
                     "pref, $formMargin, pref, $formMargin, pref, $formMargin"
                 )
             )
-                .add("CPU: ").xy(1, rows)
+                .add("${I18n.getString("termora.visual-window.system-information.cpu")}: ").xy(1, rows)
                 .add(cpuProgressBar).xy(3, rows).apply { rows += step }
                 .add("${I18n.getString("termora.visual-window.system-information.mem")}: ").xy(1, rows)
                 .add(memoryProgressBar).xy(3, rows).apply { rows += step }

--- a/src/main/kotlin/app/termora/terminal/panel/vw/VisualWindowPanel.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/vw/VisualWindowPanel.kt
@@ -137,7 +137,7 @@ open class VisualWindowPanel(protected val id: String, protected val visualWindo
         addMouseListener(object : MouseAdapter() {})
 
         toggleWindowBtn.addActionListener { toggleWindow() }
-        toggleWindowBtn.toolTipText = I18n.getString("termora.visual-window.toggle-window")
+        updateToggleWindowTooltip()
 
         addPropertyChangeListener("isWindow") {
             if (isWindow) {
@@ -147,6 +147,7 @@ open class VisualWindowPanel(protected val id: String, protected val visualWindo
                 border = BorderFactory.createMatteBorder(1, 1, 1, 1, DynamicColor.BorderColor)
                 toggleWindowBtn.icon = Icons.openInNewWindow
             }
+            updateToggleWindowTooltip()
         }
 
         // 被添加到组件后
@@ -171,6 +172,13 @@ open class VisualWindowPanel(protected val id: String, protected val visualWindo
         }
 
         closeBtn.addActionListener { if (beforeClose()) Disposer.dispose(visualWindow) }
+    }
+
+    private fun updateToggleWindowTooltip() {
+        toggleWindowBtn.toolTipText = I18n.getString(
+            if (isWindow) "termora.visual-window.return-to-panel"
+            else "termora.visual-window.open-in-new-window"
+        )
     }
 
     private fun initToolBar() {

--- a/src/main/kotlin/app/termora/tlog/TerminalLoggerAction.kt
+++ b/src/main/kotlin/app/termora/tlog/TerminalLoggerAction.kt
@@ -113,7 +113,7 @@ class TerminalLoggerAction private constructor() :
         if (SystemInfo.isMacOS) {
             fc.osxAllowedFileTypes = listOf("log")
         } else if (SystemInfo.isWindows) {
-            fc.win32Filters.add(Pair("Log files", listOf("log")))
+            fc.win32Filters.add(Pair(I18n.getString("termora.file-chooser.log-files"), listOf("log")))
         }
 
         fc.defaultDirectory = getLogDir().absolutePath

--- a/src/main/kotlin/app/termora/transfer/BookmarkButton.kt
+++ b/src/main/kotlin/app/termora/transfer/BookmarkButton.kt
@@ -35,6 +35,10 @@ class BookmarkButton : JButton(Icons.bookmarks) {
             } else {
                 Icons.bookmarks
             }
+            toolTipText = I18n.getString(
+                if (value) "termora.transport.bookmarks.remove-current"
+                else "termora.transport.bookmarks.add-current"
+            )
         }
 
 
@@ -67,7 +71,6 @@ class BookmarkButton : JButton(Icons.bookmarks) {
 
         isBookmark = false
 
-        toolTipText = I18n.getString("termora.transport.bookmarks")
     }
 
     private fun showBookmarks(e: MouseEvent) {

--- a/src/main/kotlin/app/termora/transfer/TransportPanel.kt
+++ b/src/main/kotlin/app/termora/transfer/TransportPanel.kt
@@ -411,7 +411,7 @@ internal open class TransportPanel(
                         }
 
                         override fun getPresentationName(): String {
-                            return "Path"
+                            return I18n.getString("termora.transport.path")
                         }
                     })
 

--- a/src/main/kotlin/app/termora/transfer/TransportPopupMenu.kt
+++ b/src/main/kotlin/app/termora/transfer/TransportPopupMenu.kt
@@ -149,7 +149,7 @@ internal class TransportPopupMenu(
         copyMenu.isEnabled = hasParent.not() && files.isNotEmpty()
 
         for ((item, mnemonic) in mnemonics) {
-            item.text = "${item.text}(${KeyEvent.getKeyText(mnemonic)})"
+            item.text = "${item.text} (${KeyEvent.getKeyText(mnemonic)})"
             item.setMnemonic(mnemonic)
         }
     }

--- a/src/main/kotlin/app/termora/transfer/TransportTabbed.kt
+++ b/src/main/kotlin/app/termora/transfer/TransportTabbed.kt
@@ -170,7 +170,7 @@ internal class TransportTabbed(
         val popupMenu = FlatPopupMenu()
 
         // 克隆
-        val clone = popupMenu.add(I18n.getString("termora.copy"))
+        val clone = popupMenu.add(I18n.getString("termora.tabbed.contextmenu.clone"))
         clone.addActionListener(object : AnAction() {
             override fun actionPerformed(evt: AnActionEvent) {
                 val c = addSelectionTab()

--- a/src/main/kotlin/app/termora/transfer/s3/S3Path.kt
+++ b/src/main/kotlin/app/termora/transfer/s3/S3Path.kt
@@ -1,5 +1,6 @@
 package app.termora.transfer.s3
 
+import app.termora.I18n
 import app.termora.transfer.WithPathAttributes
 import org.apache.sshd.common.file.util.BasePath
 import java.nio.file.LinkOption
@@ -43,7 +44,7 @@ open class S3Path(
     open val objectName: String get() = names.subList(1, names.size).joinToString(separator)
 
     override fun getCustomType(): String? {
-        if (isBucket) return "Bucket"
+        if (isBucket) return I18n.getString("termora.transport.type.bucket")
         return null
     }
 

--- a/src/main/kotlin/app/termora/tree/NewHostTree.kt
+++ b/src/main/kotlin/app/termora/tree/NewHostTree.kt
@@ -335,7 +335,7 @@ class NewHostTree : SimpleTree(), Disposable {
         val openWithSFTPCommand = openWith.add(I18n.getString("termora.tabbed.contextmenu.sftp-command"))
         val openInNewWindow = popupMenu.add(I18n.getString("termora.welcome.contextmenu.open-in-new-window"))
         popupMenu.addSeparator()
-        val copy = popupMenu.add(I18n.getString("termora.welcome.contextmenu.copy"))
+        val copy = popupMenu.add(I18n.getString("termora.welcome.contextmenu.duplicate"))
         val remove = popupMenu.add(I18n.getString("termora.welcome.contextmenu.remove"))
         val rename = popupMenu.add(I18n.getString("termora.welcome.contextmenu.rename"))
         popupMenu.addSeparator()
@@ -556,7 +556,7 @@ class NewHostTree : SimpleTree(), Disposable {
         )
 
         for ((item, mnemonic) in mnemonics) {
-            item.text = "${item.text}(${KeyEvent.getKeyText(mnemonic)})"
+            item.text = "${item.text} (${KeyEvent.getKeyText(mnemonic)})"
             item.setMnemonic(mnemonic)
         }
 
@@ -610,7 +610,7 @@ class NewHostTree : SimpleTree(), Disposable {
 
         val host = node.host
         val now = host.sort + 1
-        val name = if (level == 0) "${host.name} ${I18n.getString("termora.welcome.contextmenu.copy")}"
+        val name = if (level == 0) I18n.getString("termora.welcome.contextmenu.duplicate-name", host.name)
         else host.name
 
         val newHost = host.copy(
@@ -705,7 +705,7 @@ class NewHostTree : SimpleTree(), Disposable {
 
             ImportType.Xshell -> {
                 chooser.fileSelectionMode = JFileChooser.DIRECTORIES_ONLY
-                chooser.dialogTitle = "Xshell Sessions"
+                chooser.dialogTitle = I18n.getString("termora.welcome.import.xshell-sessions")
                 chooser.isAcceptAllFileFilterUsed = true
             }
 
@@ -975,7 +975,7 @@ class NewHostTree : SimpleTree(), Disposable {
             if (!SystemInfo.isWindows) {
                 OptionPane.showMessageDialog(
                     owner,
-                    "Non-UTF-8 encoded MobaXterm config files are only supported on Windows. Please convert the file to UTF-8 encoding first."
+                    I18n.getString("termora.welcome.contextmenu.import.moba-xterm-non-utf8")
                 )
                 return emptyList()
             }

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -9,12 +9,16 @@ termora.save=Save
 termora.remove=Delete
 termora.yes=Yes
 termora.no=No
+termora.message=Message
+termora.not-supported=Not supported
+termora.custom=Custom
 termora.date-format=MM/dd/yyyy hh:mm:ss a
 termora.finder=Finder
 termora.folder=Folder
 termora.file=File
 termora.explorer=Explorer
 termora.quit-confirm=Quit {0}?
+termora.database.open-failed=Unable to open database
 
 termora.regex=Regex
 termora.match-case=Match Case
@@ -30,6 +34,7 @@ termora.host.modified-server-key.thumbprint=Host key thumbprint
 termora.host.modified-server-key.expected=Expected
 termora.host.modified-server-key.actual=Actual
 termora.host.modified-server-key.are-you-sure=Are you sure you want to continue connecting?
+termora.host.modified-server-key.warning=SSH Security Warning
 
 
 # Settings
@@ -46,11 +51,15 @@ termora.settings.appearance.follow-system=Sync with OS
 termora.settings.appearance.opacity=Opacity
 termora.settings.appearance.background-running=Backgrounding
 termora.settings.appearance.tab-order=Tab Order
+termora.settings.appearance.tab-order.hide=Hide
+termora.settings.appearance.tab-order.as-needed=As needed
+termora.settings.appearance.tab-order.always=Always
 termora.settings.appearance.confirm-tab-close=Confirm tab close
 
 termora.settings.terminal=Terminal
 termora.settings.terminal.font=Font
 termora.settings.terminal.fallback-font=Fallback Font
+termora.settings.terminal.fallback-font.none=None
 termora.settings.terminal.size=Size
 termora.settings.terminal.max-rows=Max rows
 termora.settings.terminal.debug=Debug mode
@@ -74,6 +83,7 @@ termora.settings.about.author=Author
 termora.settings.about.source=Source
 termora.settings.about.issue=Issues
 termora.settings.about.third-party=Third Party
+termora.settings.about.open-source-software=Open-source software
 termora.settings.about.termora=<html><b>${termora.title}</b> ({0}) is a cross-platform SSH client. </html>
 
 termora.settings.plugin=Plugins
@@ -86,14 +96,26 @@ termora.settings.plugin.uninstall-failed=Uninstall failed
 termora.settings.plugin.install-failed=Install failed, please try again later
 termora.settings.plugin.install-from-disk=Install Plugin from Disk...
 termora.settings.plugin.manage-plugin-repository=Manage Plugin Repository...
+termora.settings.plugin.repository.title=Custom Plugin Repositories
+termora.settings.plugin.repository.add=Add Plugin Repository
 termora.settings.plugin.install-from-disk-warning=<b>{0}</b> plugin will have access to all your data. Are you sure you want to install it?
 termora.settings.plugin.not-compatible=The plugin <b>{0}</b> is incompatible with the current version. Please reinstall <b>{0}</b>
+termora.settings.plugin.marketplace.empty=No plugins found
+termora.settings.plugin.marketplace.fetch-failed=Failed to fetch plugins
+termora.settings.plugin.name.bg=Customize Background
+termora.settings.plugin.name.editor=SFTP File Editor
+termora.settings.plugin.name.geo=Geo
+termora.settings.plugin.name.migration=Migration
+termora.settings.plugin.name.serial=Serial Comm
+termora.settings.plugin.name.sync=Sync
 
 termora.settings.account=Account
 termora.settings.account.login=Log in
 termora.settings.account.server=Server
 termora.settings.account.wait-login=Waiting for login in the default browser...
 termora.settings.account.locally=locally
+termora.settings.account.local-server=Local
+termora.settings.account.local-account=Local
 termora.settings.account.lifetime=Lifetime
 termora.settings.account.upgrade=Upgrade
 termora.settings.account.verify=Verify
@@ -107,6 +129,7 @@ termora.settings.account.unsynced-logout-confirm=Unsynced Are you sure you want 
 termora.settings.account.server-singapore=Singapore
 termora.settings.account.server-china=Mainland China
 termora.settings.account.new-server=New Server
+termora.settings.account.add-server=Add
 termora.settings.account.deploy-server=Deploy
 termora.settings.account.login-failed=Log in failed, please try again later
 
@@ -116,6 +139,8 @@ termora.settings.keymap.shortcut=Shortcut
 termora.settings.keymap.action=Action
 termora.settings.keymap.already-exists=The shortcut [{0}] is already in use by [{1}]
 termora.settings.keymap.question=Select a line, press the <font color=rgb({0},{1},{2})> ⌫ (Backspace)</font> key to remove the shortcut
+termora.settings.keymap.copy-name={0} Copy
+termora.settings.keymap.copy-name-indexed={0} Copy ({1})
 
 termora.settings.sftp.edit-command=Edit Command
 termora.settings.sftp.db-click-behavior=Double-click
@@ -146,6 +171,8 @@ termora.welcome.contextmenu.connect-with=Connect with
 termora.welcome.contextmenu.open-in-new-window=${termora.tabbed.contextmenu.open-in-new-window}
 termora.welcome.contextmenu.refresh=${termora.transport.table.contextmenu.refresh}
 termora.welcome.contextmenu.copy=${termora.copy}
+termora.welcome.contextmenu.duplicate=Duplicate
+termora.welcome.contextmenu.duplicate-name=Copy of {0}
 termora.welcome.contextmenu.remove=${termora.remove}
 termora.welcome.contextmenu.rename=Rename
 termora.welcome.contextmenu.expand-all=Expand all
@@ -165,6 +192,7 @@ termora.welcome.contextmenu.import.csv.download-template-done=Download the templ
 termora.welcome.contextmenu.import.csv.download-template-done-open-folder=Download the template successfully, Do you want to open the folder?
 termora.welcome.contextmenu.import.xshell-folder-empty=The folder does not contain any *.xsh files, Please select the correct Xshell Sessions directory
 termora.welcome.contextmenu.import.finalshell-folder-empty=The folder does not contain any *_connect_config.json files, Please select the correct FinalShell directory
+termora.welcome.contextmenu.import.moba-xterm-non-utf8=Non-UTF-8 encoded MobaXterm configuration files are supported only on Windows. Convert the file to UTF-8 first
 
 # New Host
 termora.new-host.title=Create a new host
@@ -176,6 +204,11 @@ termora.new-host.general.port=Port
 termora.new-host.general.username=Username
 termora.new-host.general.authentication=Authentication
 termora.new-host.general.password=Password
+termora.new-host.general.authentication.none=None
+termora.new-host.general.authentication.password=${termora.new-host.general.password}
+termora.new-host.general.authentication.public-key=Public key
+termora.new-host.general.authentication.ssh-agent=SSH agent
+termora.new-host.general.authentication.keyboard-interactive=Keyboard interactive
 termora.new-host.general.remark=Comment
 termora.new-host.general.remember=Remember
 
@@ -203,12 +236,26 @@ termora.new-host.serial.data-bits=Data bits
 termora.new-host.serial.parity=Parity
 termora.new-host.serial.stop-bits=Stop bits
 termora.new-host.serial.flow-control=Flow control
+termora.new-host.serial.parity.none=None
+termora.new-host.serial.parity.even=Even
+termora.new-host.serial.parity.odd=Odd
+termora.new-host.serial.parity.mark=Mark (1)
+termora.new-host.serial.parity.space=Space (0)
+termora.new-host.serial.flow-control.none=None
 
 termora.new-host.tunneling=Tunneling
+termora.new-host.tunneling.x11=X11 forwarding
+termora.new-host.tunneling.x-display=X display
+termora.new-host.tunneling.agent=Agent forwarding
+termora.new-host.tunneling.agent.enable=Enable agent forwarding
+termora.new-host.tunneling.tcp=TCP/IP forwarding
 termora.new-host.tunneling.table.name=Name
 termora.new-host.tunneling.table.type=Type
 termora.new-host.tunneling.table.source=Source
 termora.new-host.tunneling.table.destination=Destination
+termora.new-host.tunneling.type.local=Local
+termora.new-host.tunneling.type.remote=Remote
+termora.new-host.tunneling.type.dynamic=Dynamic
 termora.new-host.tunneling.add=Add
 termora.new-host.tunneling.edit=${termora.keymgr.edit}
 termora.new-host.tunneling.delete=${termora.remove}
@@ -240,11 +287,23 @@ termora.keymgr.table.length=Length
 termora.keymgr.table.remark=Description
 termora.keymgr.export-done=The export was successful
 termora.keymgr.export-done-open-folder=The export was successful. Do you want to open the folder?
+termora.keymgr.import.error=Failed to import the key
+termora.keymgr.import.load-failed=Failed to load the key file
+termora.keymgr.import.unsupported-key-type=Key type: {0}. Only RSA, ED25519, and ECDSA keys are supported
 
 termora.keymgr.ssh-copy-id.number=Number of hosts [{0}]    Number of public keys [{1}]
 termora.keymgr.ssh-copy-id.successful=${termora.terminal.copied}
 termora.keymgr.ssh-copy-id.failed=Copy Failure
 termora.keymgr.ssh-copy-id.end=End of public key copying
+termora.keymgr.ssh-copy-id.title=Copy public key to hosts
+termora.file-chooser.all-files=All files
+termora.file-chooser.zip-files=ZIP archives
+termora.file-chooser.json-files=JSON files
+termora.file-chooser.log-files=Log files
+termora.file-chooser.image-files=Images
+termora.settings.appearance.theme.dark-os=For dark OS theme
+termora.settings.appearance.theme.light-os=For light OS theme
+termora.welcome.import.xshell-sessions=Xshell sessions folder
 
 
 # Tabbed
@@ -281,6 +340,10 @@ termora.highlight.keyword=Keyword
 termora.highlight.my-keyword=My Keyword
 termora.highlight.preview=Preview
 termora.highlight.description=Description
+termora.highlight.preview-text=Highlight
+termora.highlight.color-picker=Color picker
+termora.highlight.use-terminal-foreground=Use terminal foreground color
+termora.highlight.use-terminal-background=Use terminal background color
 termora.highlight.bold=Bold
 termora.highlight.italic=Italic
 termora.highlight.underline=Underline
@@ -308,6 +371,8 @@ termora.tools.multiple=Send command to the current window sessions
 
 # Transport
 termora.transport.local=Local
+termora.transport.path=Path
+termora.transport.type.bucket=Bucket
 termora.transport.file-already-exists=The file {0} already exists
 
 
@@ -319,6 +384,8 @@ termora.transport.toolbar.show-hide=Show/Hide Folders
 termora.transport.toolbar.refresh=Refresh Folder
 
 termora.transport.bookmarks=Bookmarks Manager
+termora.transport.bookmarks.add-current=Add current folder to bookmarks
+termora.transport.bookmarks.remove-current=Remove current folder from bookmarks
 termora.transport.bookmarks.up=Up
 termora.transport.bookmarks.down=Down
 
@@ -337,7 +404,7 @@ termora.transport.table.contextmenu.copy-path=Copy Path
 termora.transport.table.contextmenu.open-in-folder=Open in {0}
 termora.transport.table.contextmenu.rename=${termora.welcome.contextmenu.rename}
 termora.transport.table.contextmenu.delete=${termora.remove}
-termora.transport.table.contextmenu.rm-warning=Using the rm -rf command to delete a file is very dangerous
+termora.transport.table.contextmenu.rm-warning=Using the rm -rf command to delete a file is very dangerous. Are you sure you want to continue?
 termora.transport.table.contextmenu.change-permissions=Change Permissions...
 termora.transport.table.contextmenu.refresh=Refresh
 termora.transport.table.contextmenu.compress=Compress
@@ -434,20 +501,46 @@ termora.terminal.channel-reconnect=Type {0} to reconnect.
 
 # protocol
 termora.protocol.not-supported={0} protocol is not supported, you may need to install the plugin
+termora.vnc.error.authentication-failed=VNC authentication failed
+termora.vnc.error.unsupported-protocol=The VNC server uses an unsupported protocol version
+termora.vnc.error.unsupported-security=The VNC server uses an unsupported security type
+termora.vnc.error.timeout=The VNC connection timed out
+termora.vnc.error.unknown-host=The VNC server address could not be resolved
+termora.vnc.error.connection-failed=Could not connect to the VNC server
+termora.vnc.error.generic=An error occurred while connecting to the VNC server
+termora.ssh.user-authentication=SSH user authentication
+termora.find-everywhere.nothing-found=Nothing found
+
+# Object storage
+termora.object-storage.endpoint=Endpoint
+termora.object-storage.access-key=Access key
+termora.object-storage.secret-id=Secret ID
+termora.object-storage.secret-key=Secret key
+termora.object-storage.region=Region
+termora.object-storage.delimiter=Delimiter
 
 # Visual Window
 termora.visual-window.system-information=System information
+termora.visual-window.system-information.cpu=CPU
 termora.visual-window.system-information.mem=Mem
 termora.visual-window.system-information.swap=Swap
 termora.visual-window.system-information.filesystem=Filesystem
 termora.visual-window.system-information.used-total=Used / Total
 termora.visual-window.toggle-window=Toggle window
+termora.visual-window.open-in-new-window=Open in a separate window
+termora.visual-window.return-to-panel=Return to panel
 termora.visual-window.transport.question=More Features
 
 termora.visual-window.command-history=Command History
 
 
 termora.visual-window.nvidia-smi=NVIDIA SMI
+termora.visual-window.nvidia-smi.gpu=GPU
+termora.visual-window.nvidia-smi.temperature=Temperature
+termora.visual-window.nvidia-smi.memory=Memory
+termora.visual-window.nvidia-smi.power=Power
+termora.visual-window.nvidia-smi.driver=Driver
+termora.visual-window.nvidia-smi.gpus=GPUs
 
 
 termora.floating-toolbar.close-in-current-tab=Close in current tab

--- a/src/main/resources/i18n/messages_de_DE.properties
+++ b/src/main/resources/i18n/messages_de_DE.properties
@@ -319,6 +319,8 @@ termora.transport.toolbar.show-hide=Ordner ein-/ausblenden
 termora.transport.toolbar.refresh=Ordner aktualisieren
 
 termora.transport.bookmarks=Lesezeichen verwalten
+termora.transport.bookmarks.add-current=Aktuellen Ordner zu den Lesezeichen hinzufügen
+termora.transport.bookmarks.remove-current=Aktuellen Ordner aus den Lesezeichen entfernen
 termora.transport.bookmarks.up=Nach oben
 termora.transport.bookmarks.down=Nach unten
 

--- a/src/main/resources/i18n/messages_pt_BR.properties
+++ b/src/main/resources/i18n/messages_pt_BR.properties
@@ -319,6 +319,8 @@ termora.transport.toolbar.show-hide=Mostrar/Ocultar Pastas
 termora.transport.toolbar.refresh=Atualizar Pasta
 
 termora.transport.bookmarks=Gerenciador de Favoritos
+termora.transport.bookmarks.add-current=Adicionar pasta atual aos favoritos
+termora.transport.bookmarks.remove-current=Remover pasta atual dos favoritos
 termora.transport.bookmarks.up=Para cima
 termora.transport.bookmarks.down=Para baixo
 

--- a/src/main/resources/i18n/messages_ru_RU.properties
+++ b/src/main/resources/i18n/messages_ru_RU.properties
@@ -1,6 +1,6 @@
 termora.title=Termora
-termora.confirm=Ок
-termora.exit=покидать
+termora.confirm=ОК
+termora.exit=Выйти
 termora.cancel=Отмена
 termora.copy=Копировать
 termora.paste=Вставить
@@ -9,154 +9,202 @@ termora.save=Сохранить
 termora.remove=Удалить
 termora.yes=Да
 termora.no=Нет
+termora.message=Сообщение
+termora.not-supported=Не поддерживается
+termora.custom=Другой цвет
 termora.date-format=dd.MM.yyyy HH:mm:ss
-termora.finder=Поисковик
+termora.finder=Finder
 termora.folder=Папка
+termora.file=Файл
 termora.explorer=Проводник
-termora.quit-confirm=Выйти {0}?
+termora.quit-confirm=Выйти из {0}?
+termora.database.open-failed=Не удалось открыть базу данных
 
+termora.regex=Регулярное выражение
+termora.match-case=Учитывать регистр
+termora.optional=Необязательно
 
 # update
-termora.update.title=Новая версия
+termora.update.title=Доступна новая версия
 termora.update.update=Обновить
 
-
 # Hosts
-termora.host.modified-server-key.title=HOST [{0}] ИДЕНТИФИКАЦИЯ ИЗМЕНИЛАСЬ
+termora.host.modified-server-key.title=ИДЕНТИФИКАЦИОННЫЙ КЛЮЧ ХОСТА [{0}] ИЗМЕНИЛСЯ
 termora.host.modified-server-key.thumbprint=Отпечаток ключа хоста
-termora.host.modified-server-key.expected=Ожидаемый
-termora.host.modified-server-key.actual=Актуальный
+termora.host.modified-server-key.expected=Ожидался
+termora.host.modified-server-key.actual=Получен
 termora.host.modified-server-key.are-you-sure=Вы уверены, что хотите продолжить подключение?
-
+termora.host.modified-server-key.warning=Предупреждение безопасности SSH
 
 # Settings
 termora.setting=Настройки
 
-termora.settings.appearance=Внешний вид
+termora.settings.appearance=Общие
 termora.settings.appearance.theme=Тема
+termora.settings.appearance.layout=Компоновка
+termora.settings.appearance.layout.screen=Экран
+termora.settings.appearance.layout.fence=Раздельный вид
 termora.settings.appearance.language=Язык
-termora.settings.appearance.i-want-to-translate=Помочь с переводом
+termora.settings.appearance.i-want-to-translate=Я хочу помочь с переводом
 termora.settings.appearance.follow-system=Как в системе
 termora.settings.appearance.opacity=Прозрачность
-termora.settings.appearance.background-image=Фоновое изображение
-termora.settings.appearance.background-running=Фон
-termora.settings.appearance.tab-order=Порядок вкладок
-termora.settings.appearance.confirm-tab-close=Подтверждение закрытия вкладки
+termora.settings.appearance.background-running=Работа в фоновом режиме
+termora.settings.appearance.tab-order=Номера вкладок
+termora.settings.appearance.tab-order.hide=Не показывать
+termora.settings.appearance.tab-order.as-needed=При переключении
+termora.settings.appearance.tab-order.always=Показывать всегда
+termora.settings.appearance.confirm-tab-close=Подтверждать закрытие вкладки
 
-termora.setting.security=Безопасность
-termora.setting.security.enter-password=Введите пароль
-termora.setting.security.enter-password-again=Повторите пароль
-termora.setting.security.password-is-different=Пароли отличаются
-termora.setting.security.mnemonic-note=Сохраните мнемоническую фразу в надежном месте, она может помочь восстановить данные, если вы забудете пароль
+termora.settings.terminal=Терминал
+termora.settings.terminal.font=Шрифт
+termora.settings.terminal.fallback-font=Резервный шрифт
+termora.settings.terminal.fallback-font.none=Не выбран
+termora.settings.terminal.size=Размер
+termora.settings.terminal.max-rows=Максимальное число строк
+termora.settings.terminal.debug=Режим отладки
+termora.settings.terminal.beep=Звуковой сигнал
+termora.settings.terminal.hyperlink=Гиперссылки
+termora.settings.terminal.select-copy=Копировать при выделении
+termora.settings.terminal.right-click=Правая кнопка мыши
+termora.settings.terminal.right-click.copy-and-paste=Копировать и вставлять
+termora.settings.terminal.right-click.nothing=Ничего не делать
+termora.settings.terminal.right-click.copy=${termora.copy}
+termora.settings.terminal.cursor-style=Вид курсора
+termora.settings.terminal.cursor-blink=Мигающий курсор
+termora.settings.terminal.local-shell=Локальная оболочка
+termora.settings.terminal.floating-toolbar=Плавающая панель инструментов
+termora.settings.terminal.auto-close-tab=Автоматически закрывать вкладку
+termora.settings.terminal.auto-close-tab-description=Автоматически закрывать вкладку после штатного отключения терминала
+
+termora.settings.about=О программе
+termora.settings.about.author=Автор
+termora.settings.about.source=Исходный код
+termora.settings.about.issue=Сообщить о проблеме
+termora.settings.about.third-party=Сторонние компоненты
+termora.settings.about.open-source-software=Открытое ПО
+termora.settings.about.termora=<html><b>${termora.title}</b> ({0}) — кроссплатформенный SSH-клиент.</html>
+
+termora.settings.plugin=Плагины
+termora.settings.plugin.install=Установить
+termora.settings.plugin.installed=Установленные
+termora.settings.plugin.marketplace=Каталог плагинов
+termora.settings.plugin.uninstall=Удалить
+termora.settings.plugin.uninstall-confirm=Вы уверены, что хотите удалить плагин <b>{0}</b>?
+termora.settings.plugin.uninstall-failed=Не удалось удалить плагин
+termora.settings.plugin.install-failed=Не удалось установить плагин. Повторите попытку позже
+termora.settings.plugin.install-from-disk=Установить плагин с диска...
+termora.settings.plugin.manage-plugin-repository=Управление репозиториями плагинов...
+termora.settings.plugin.repository.title=Пользовательские репозитории плагинов
+termora.settings.plugin.repository.add=Добавить репозиторий плагинов
+termora.settings.plugin.install-from-disk-warning=Плагин <b>{0}</b> получит доступ ко всем вашим данным. Вы уверены, что хотите его установить?
+termora.settings.plugin.not-compatible=Плагин <b>{0}</b> несовместим с текущей версией. Переустановите <b>{0}</b>
+termora.settings.plugin.marketplace.empty=Плагины не найдены
+termora.settings.plugin.marketplace.fetch-failed=Не удалось загрузить список плагинов
+termora.settings.plugin.name.bg=Настройка фона
+termora.settings.plugin.name.editor=Редактор файлов SFTP
+termora.settings.plugin.name.geo=Геолокация
+termora.settings.plugin.name.migration=Перенос данных
+termora.settings.plugin.name.serial=Последовательный порт
+termora.settings.plugin.name.sync=Синхронизация
 
 termora.settings.account=Учётная запись
 termora.settings.account.login=Войти
 termora.settings.account.server=Сервер
-termora.settings.account.wait-login=Ожидание входа в браузере по умолчанию...
-termora.settings.account.locally=локально
-termora.settings.account.lifetime=Время действия
-termora.settings.account.upgrade=Обновить
-termora.settings.account.verify=Подтвердить
+termora.settings.account.wait-login=Ожидание входа через браузер по умолчанию...
+termora.settings.account.locally=Локально
+termora.settings.account.local-server=Локальный
+termora.settings.account.local-account=Локальная
+termora.settings.account.lifetime=Бессрочно
+termora.settings.account.upgrade=Повысить тариф
+termora.settings.account.verify=Проверить
 termora.settings.account.subscription=Подписка
-termora.settings.account.valid-to=Действительна до
-termora.settings.account.synchronization-on=Синхронизация вкл
-termora.settings.account.sync-now = Синхронизировать сейчас
-termora.settings.account.logout = Выйти
-termora.settings.account.logout-confirm = Вы уверены, что хотите выйти?
-termora.settings.account.unsynced-logout-confirm = Несинхронизировано Вы уверены, что хотите выйти?
-termora.settings.account.server-singapore = Сингапур
-termora.settings.account.server-china = Материковый Китай
-termora.settings.account.new-server = Новый сервер
-termora.settings.account.deploy-server = Развернуть
-termora.settings.account.login-failed = Не удалось войти, повторите попытку позже
+termora.settings.account.valid-to=Действует до
+termora.settings.account.synchronization-on=Синхронизация включена
+termora.settings.account.sync-now=Синхронизировать сейчас
+termora.settings.account.logout=Выйти
+termora.settings.account.logout-confirm=Вы уверены, что хотите выйти из учётной записи?
+termora.settings.account.unsynced-logout-confirm=Есть несинхронизированные изменения. Вы уверены, что хотите выйти из учётной записи?
+termora.settings.account.server-singapore=Сингапур
+termora.settings.account.server-china=Материковый Китай
+termora.settings.account.new-server=Новый сервер
+termora.settings.account.add-server=Добавить
+termora.settings.account.deploy-server=Развернуть
+termora.settings.account.login-failed=Не удалось войти. Повторите попытку позже
 
+termora.settings.keymap=Сочетания клавиш
+termora.settings.keymap.shortcut=Сочетание клавиш
+termora.settings.keymap.action=Действие
+termora.settings.keymap.already-exists=Сочетание клавиш [{0}] уже используется для действия [{1}]
+termora.settings.keymap.question=Выберите строку и нажмите <font color=rgb({0},{1},{2})>⌫ (Backspace)</font>, чтобы удалить сочетание клавиш
+termora.settings.keymap.copy-name=Копия {0}
+termora.settings.keymap.copy-name-indexed=Копия {0} ({1})
 
-termora.settings.terminal=Терминал
-termora.settings.terminal.font=Шрифт
-termora.settings.terminal.size=Размер
-termora.settings.terminal.max-rows=Максимум строк
-termora.settings.terminal.debug=Режим отладки
-termora.settings.terminal.beep=Сигнал
-termora.settings.terminal.hyperlink=Ссылки
-termora.settings.terminal.select-copy=Копировать выделенное
-termora.settings.terminal.right-click=правой кнопкой мыши
-termora.settings.terminal.right-click.copy-and-paste=Копировать и вставить
-termora.settings.terminal.right-click.nothing=никто
-termora.settings.terminal.cursor-style=Вид курсора
-termora.settings.terminal.cursor-blink=Мигать курсором
-termora.settings.terminal.local-shell=Локальный терминал
-termora.settings.terminal.floating-toolbar=Плавающая панель
-termora.settings.terminal.auto-close-tab=Автозакрытие вкладки
-termora.settings.terminal.auto-close-tab-description=Автоматически закрывать вкладку при обычном отключении терминала
-
-termora.settings.about=О программе
-termora.settings.about.author=Автор
-termora.settings.about.source=Ссылка
-termora.settings.about.issue=Обсуждения
-termora.settings.about.third-party=Третья сторона
-termora.settings.about.termora=<html><b>${termora.title}</b> ({0}) кроссплатформенный SSH клиент. </html>
-
-termora.settings.keymap=Горяиче клавиши
-termora.settings.keymap.shortcut=Комбинация
-termora.settings.keymap.action=Команда
-termora.settings.keymap.already-exists=Комбинация [{0}] уже используется [{1}]
-termora.settings.keymap.question=Выберите строку и нажмите <font color=rgb({0},{1},{2})> ⌫ (клавишу Backspace)</font>, чтобы удалить сочетание клавиш
-
-termora.settings.sftp.edit-command=Редактировать команду
-termora.settings.sftp.db-click-behavior=двойной щелчок
-termora.settings.sftp.fixed-tab=Отображать вкладку
-termora.settings.sftp.default-directory=Директория по умолчанию
-termora.settings.sftp.preserve-time=Сохранять исходное время модификации файла
-
+termora.settings.sftp.edit-command=Команда редактирования
+termora.settings.sftp.db-click-behavior=Действие по двойному щелчку
+termora.settings.sftp.fixed-tab=Закреплённая вкладка
+termora.settings.sftp.default-directory=Каталог по умолчанию
+termora.settings.sftp.preserve-time=Сохранять исходное время изменения файла
 
 termora.settings.restart.title=Перезапуск
-termora.settings.restart.message=Изменения вступят в силу после перезапуска приложения.
+termora.settings.restart.message=Изменения вступят в силу после перезапуска приложения
+termora.settings.restart.manually=Перезапустите приложение вручную
 
 # Find everywhere
-termora.find-everywhere=Искать везде
-termora.find-everywhere.search-for-something=Поиск чего-либо ...
+termora.find-everywhere=Поиск повсюду
+termora.find-everywhere.search-for-something=Введите запрос...
 termora.find-everywhere.groups.quick-actions=Быстрые действия
 termora.find-everywhere.groups.open-new-hosts=Открыть новый хост
 termora.find-everywhere.groups.opened-hosts=Открытые хосты
-termora.find-everywhere.groups.tools=Утилиты
+termora.find-everywhere.groups.tools=Инструменты
 termora.find-everywhere.groups.settings=${termora.setting}
 termora.find-everywhere.quick-command.local-terminal=Локальный терминал
 
 # Welcome
 termora.welcome.my-hosts=Мои хосты
+termora.welcome.toggle-sidebar=Показать или скрыть боковую панель
 termora.welcome.contextmenu.connect=Подключиться
-termora.welcome.contextmenu.connect-with=Подключиться через
+termora.welcome.contextmenu.connect-with=Подключиться с помощью
 termora.welcome.contextmenu.open-in-new-window=${termora.tabbed.contextmenu.open-in-new-window}
 termora.welcome.contextmenu.refresh=${termora.transport.table.contextmenu.refresh}
 termora.welcome.contextmenu.copy=${termora.copy}
+termora.welcome.contextmenu.duplicate=Дублировать
+termora.welcome.contextmenu.duplicate-name=Копия {0}
 termora.welcome.contextmenu.remove=${termora.remove}
 termora.welcome.contextmenu.rename=Переименовать
-termora.welcome.contextmenu.expand-all=Раскрыть все
-termora.welcome.contextmenu.collapse-all=Свернуть все
-termora.welcome.contextmenu.new=Новый
+termora.welcome.contextmenu.expand-all=Развернуть всё
+termora.welcome.contextmenu.collapse-all=Свернуть всё
+termora.welcome.contextmenu.new=Создать
 termora.welcome.contextmenu.import=${termora.keymgr.import}
 termora.welcome.contextmenu.new.folder=${termora.folder}
 termora.welcome.contextmenu.new.host=Хост
 termora.welcome.contextmenu.new.folder.name=Новая папка
 termora.welcome.contextmenu.property=Свойства
-termora.welcome.contextmenu.show-more-info=Показать больше информации
+termora.welcome.contextmenu.show=Показать
+termora.welcome.contextmenu.show.more-info=Подробные сведения
+termora.welcome.contextmenu.show.tags=${termora.tag}
 termora.welcome.contextmenu.download=Скачать
-termora.welcome.contextmenu.import.csv.download-template=Импортировать или загрузить шаблон?
-termora.welcome.contextmenu.import.csv.download-template-done=Шаблон успешно загружен
-termora.welcome.contextmenu.import.csv.download-template-done-open-folder=Шаблон успешно загружен. Открыть папку?
-termora.welcome.contextmenu.import.xshell-folder-empty=Папка не содержит файлов *.xsh. Выберите правильный каталог сессий Xshell.
-termora.welcome.contextmenu.import.finalshell-folder-empty=Папка не содержит файлов *_connect_config.json. Выберите правильный каталог FinalShell.
+termora.welcome.contextmenu.import.csv.download-template=Импортировать данные или скачать шаблон?
+termora.welcome.contextmenu.import.csv.download-template-done=Шаблон успешно скачан
+termora.welcome.contextmenu.import.csv.download-template-done-open-folder=Шаблон успешно скачан. Открыть папку?
+termora.welcome.contextmenu.import.xshell-folder-empty=В папке нет файлов *.xsh. Выберите правильный каталог сеансов Xshell
+termora.welcome.contextmenu.import.finalshell-folder-empty=В папке нет файлов *_connect_config.json. Выберите правильный каталог FinalShell
+termora.welcome.contextmenu.import.moba-xterm-non-utf8=Конфигурационные файлы MobaXterm в кодировке, отличной от UTF-8, поддерживаются только в Windows. Сначала преобразуйте файл в UTF-8
 
 # New Host
-termora.new-host.title=Добавить новый хост
-termora.new-host.general=Основное
-termora.new-host.general.name=Название
+termora.new-host.title=Создание хоста
+termora.new-host.general=Общие
+termora.new-host.general.name=Имя
 termora.new-host.general.protocol=Протокол
 termora.new-host.general.host=Хост
 termora.new-host.general.port=Порт
-termora.new-host.general.username=Пользователь
+termora.new-host.general.username=Имя пользователя
 termora.new-host.general.authentication=Аутентификация
 termora.new-host.general.password=Пароль
+termora.new-host.general.authentication.none=Без аутентификации
+termora.new-host.general.authentication.password=${termora.new-host.general.password}
+termora.new-host.general.authentication.public-key=Открытый ключ
+termora.new-host.general.authentication.ssh-agent=SSH-агент
+termora.new-host.general.authentication.keyboard-interactive=Интерактивная аутентификация
 termora.new-host.general.remark=Комментарий
 termora.new-host.general.remember=Запомнить
 
@@ -164,240 +212,325 @@ termora.new-host.proxy=Прокси
 
 termora.new-host.terminal=${termora.settings.terminal}
 termora.new-host.terminal.encoding=Кодировка
-termora.new-host.terminal.heartbeat-interval=Интервал опроса
+termora.new-host.terminal.backspace=Клавиша Backspace
+termora.new-host.terminal.character-mode=Посимвольный режим
+termora.new-host.terminal.heartbeat-interval=Интервал проверки соединения
 termora.new-host.terminal.timeout=Тайм-аут
-termora.new-host.terminal.startup-commands=Команда запуска
-termora.new-host.terminal.env=переменные
+termora.new-host.terminal.startup-commands=Команда при запуске
+termora.new-host.terminal.alt-modifier=Модификатор Alt
+termora.new-host.terminal.alt-modifier.eight-bit=8-битные символы
+termora.new-host.terminal.alt-modifier.by-esc=Символы с префиксом ESC
+termora.new-host.terminal.env=Переменные окружения
+termora.new-host.terminal.login-scripts=Сценарии входа
+termora.new-host.terminal.expect=Ожидаемый текст
+termora.new-host.terminal.send=Отправить в ответ
 
-termora.new-host.serial=Серийный
+termora.new-host.serial=Последовательный порт
 termora.new-host.serial.port=Порт
-termora.new-host.serial.baud-rate=Скорость
-termora.new-host.serial.data-bits=Бит данных
-termora.new-host.serial.parity=Паритет
-termora.new-host.serial.stop-bits=Стоп биты
+termora.new-host.serial.baud-rate=Скорость передачи
+termora.new-host.serial.data-bits=Биты данных
+termora.new-host.serial.parity=Чётность
+termora.new-host.serial.stop-bits=Стоповые биты
 termora.new-host.serial.flow-control=Управление потоком
+termora.new-host.serial.parity.none=Нет
+termora.new-host.serial.parity.even=Чётная
+termora.new-host.serial.parity.odd=Нечётная
+termora.new-host.serial.parity.mark=Маркер (1)
+termora.new-host.serial.parity.space=Пробел (0)
+termora.new-host.serial.flow-control.none=Нет
 
-termora.new-host.tunneling=Туннелирование
-termora.new-host.tunneling.table.name=Название
+termora.new-host.tunneling=Туннели
+termora.new-host.tunneling.x11=Перенаправление X11
+termora.new-host.tunneling.x-display=Дисплей X11
+termora.new-host.tunneling.agent=Перенаправление SSH-агента
+termora.new-host.tunneling.agent.enable=Включить перенаправление агента
+termora.new-host.tunneling.tcp=Перенаправление TCP/IP
+termora.new-host.tunneling.table.name=Имя
 termora.new-host.tunneling.table.type=Тип
 termora.new-host.tunneling.table.source=Источник
 termora.new-host.tunneling.table.destination=Назначение
+termora.new-host.tunneling.type.local=Локальный
+termora.new-host.tunneling.type.remote=Удалённый
+termora.new-host.tunneling.type.dynamic=Динамический
 termora.new-host.tunneling.add=Добавить
 termora.new-host.tunneling.edit=${termora.keymgr.edit}
 termora.new-host.tunneling.delete=${termora.remove}
 
-termora.new-host.test-connection=Тест соединения
-termora.new-host.test-connection-successful=Соединение успешно
+termora.new-host.rdp.desktop-placeholder=По умолчанию — весь экран (например, 1920×1080)
+termora.new-host.rdp.resolution=Разрешение
 
+termora.new-host.wsl.distribution=Имя дистрибутива
 
-termora.new-host.jump-hosts=Прыжки хостов
+termora.new-host.test-connection=Проверить подключение
+termora.new-host.test-connection-successful=Подключение установлено
+
+termora.new-host.jump-hosts=Промежуточные хосты
 
 # Key manager
 termora.keymgr.title=Менеджер ключей
-termora.keymgr.generate=Генерировать
+termora.keymgr.my-keys=Мои ключи
+termora.keymgr.generate=Создать
 termora.keymgr.import=Импорт
 termora.keymgr.export=Экспорт
-termora.keymgr.edit=Редактировать
-termora.keymgr.delete-warning=Вы уверены, что хотите удалить?
-termora.keymgr.table.name=Название
+termora.keymgr.edit=Изменить
+termora.keymgr.private-key=Закрытый ключ
+termora.keymgr.delete-warning=Вы уверены, что хотите удалить этот ключ?
+termora.keymgr.table.name=Имя
 termora.keymgr.table.type=Тип
 termora.keymgr.table.length=Длина
 termora.keymgr.table.remark=Описание
-termora.keymgr.export-done=Экспорт выполнен успешно
-termora.keymgr.export-done-open-folder=Экспорт выполнен успешно. Открыть папку?
+termora.keymgr.export-done=Экспорт завершён
+termora.keymgr.export-done-open-folder=Экспорт завершён. Открыть папку?
+termora.keymgr.import.error=Не удалось импортировать ключ
+termora.keymgr.import.load-failed=Не удалось загрузить файл ключа
+termora.keymgr.import.unsupported-key-type=Тип ключа: {0}. Поддерживаются только ключи RSA, ED25519 и ECDSA
 
-termora.keymgr.ssh-copy-id.number=Кол-во хостов [{0}]    Кол-во публичных ключей [{1}]
+termora.keymgr.ssh-copy-id.number=Хостов: [{0}]    Открытых ключей: [{1}]
 termora.keymgr.ssh-copy-id.successful=${termora.terminal.copied}
-termora.keymgr.ssh-copy-id.failed=Ошибка копирования
-termora.keymgr.ssh-copy-id.end=Копирования открытого ключа завершено
+termora.keymgr.ssh-copy-id.failed=Не удалось скопировать
+termora.keymgr.ssh-copy-id.end=Копирование открытых ключей завершено
+termora.keymgr.ssh-copy-id.title=Копирование открытого ключа на хосты
+termora.file-chooser.all-files=Все файлы
+termora.file-chooser.zip-files=Архивы ZIP
+termora.file-chooser.json-files=Файлы JSON
+termora.file-chooser.log-files=Файлы журналов
+termora.file-chooser.image-files=Изображения
+termora.settings.appearance.theme.dark-os=Для тёмной темы ОС
+termora.settings.appearance.theme.light-os=Для светлой темы ОС
+termora.welcome.import.xshell-sessions=Папка сеансов Xshell
 
 # Tabbed
 termora.tabbed.contextmenu.rename=Переименовать
 termora.tabbed.contextmenu.select-host=Выбрать хост
-termora.tabbed.contextmenu.sftp-command=SFTP Команда
-termora.tabbed.contextmenu.sftp-not-install=Программа SFTP не найдена, пожалуйста, установите и повторите попытку.
-termora.tabbed.contextmenu.clone=Дублировать
-termora.tabbed.contextmenu.open-in-new-window=Открыть в Новом Окне
+termora.tabbed.contextmenu.sftp-command=Терминал SFTP
+termora.tabbed.contextmenu.sftp-not-install=Программа SFTP не найдена. Установите её и повторите попытку
+termora.tabbed.contextmenu.clone=Дублировать подключение
+termora.tabbed.contextmenu.clone-session=Дублировать сеанс
+termora.tabbed.contextmenu.open-in-new-window=Открыть в новом окне
 termora.tabbed.contextmenu.close=Закрыть
 termora.tabbed.contextmenu.close-other-tabs=Закрыть другие вкладки
 termora.tabbed.contextmenu.close-all-tabs=Закрыть все вкладки
 termora.tabbed.contextmenu.reconnect=Переподключиться
-termora.tabbed.local-tab.close-prompt=Хотите ли вы завершить запущенный процесс в этом терминале?
+termora.tabbed.local-tab.close-prompt=Завершить процесс, запущенный в этом терминале?
 termora.tabbed.tab.close-prompt=Вы уверены, что хотите закрыть эту вкладку?
 
 # Terminal logger
-termora.terminal-logger=Журнал Терминала
-termora.terminal-logger.start-recording=Начать Запись
+termora.terminal-logger=Журнал терминала
+termora.terminal-logger.start-recording=Начать запись
 termora.terminal-logger.plain-text=Обычный текст
-termora.terminal-logger.styled-text=Стилизованный текст
-termora.terminal-logger.stop-recording=Остановить Запись
-termora.terminal-logger.open-log-viewer=Открыть Журнал
+termora.terminal-logger.styled-text=Форматированный текст
+termora.terminal-logger.stop-recording=Остановить запись
+termora.terminal-logger.open-log-viewer=Просмотреть журнал
 termora.terminal-logger.open-in-folder=Открыть в {0}
 
-
 # Highlight
-termora.highlight=Персонализация
-termora.highlight.default-set=Набор по умолчанию
-termora.highlight.text-color=Цвет Текста
-termora.highlight.background-color=Фоновый Цвет
-termora.highlight.keyword=Слово
-termora.highlight.preview=Предпросмотр
+termora.highlight=Правила подсветки
+termora.highlight.default-set=Основные правила
+termora.highlight.text-color=Цвет текста
+termora.highlight.background-color=Цвет фона
+termora.highlight.keyword=Искомый текст
+termora.highlight.my-keyword=Мои правила
+termora.highlight.preview=Пример
 termora.highlight.description=Описание
-termora.highlight.bold=Жирный
+termora.highlight.preview-text=Пример
+termora.highlight.color-picker=Выбор цвета
+termora.highlight.use-terminal-foreground=Использовать цвет текста терминала
+termora.highlight.use-terminal-background=Использовать цвет фона терминала
+termora.highlight.bold=Полужирный
 termora.highlight.italic=Курсив
-termora.highlight.underline=Подчеркнутый
-termora.highlight.line-through=Зачеркнутый
+termora.highlight.underline=Подчёркивание
+termora.highlight.line-through=Зачёркивание
+
+# tag
+termora.tag=Теги
+termora.tag.my-tags=Мои теги
+termora.tag.manage-tags=Управление тегами
 
 # Macro
 termora.macro=Макросы
-termora.macro.start-recording=Начать Запись
-termora.macro.stop-recording=Остановить Запись
+termora.macro.start-recording=Начать запись
+termora.macro.stop-recording=Остановить запись
 termora.macro.playback=Воспроизвести
-termora.macro.manager=Менеджер Макросов
-termora.macro.run=Выполнить
+termora.macro.manager=Управление макросами
+termora.macro.run=Запустить
 
 # Snippets
 termora.snippet=Команда
-termora.snippet.title=Команды
+termora.snippet.title=Сохранённые команды
 
 # Tools
-termora.tools.multiple=Отправить команду в текущие сеансы окна
+termora.tools.multiple=Отправить команду во все сеансы текущего окна
 
 # Transport
-termora.transport.local=Локально
+termora.transport.local=Локальный компьютер
+termora.transport.path=Путь
+termora.transport.type.bucket=Бакет
 termora.transport.file-already-exists=Файл {0} уже существует
-
-termora.transport.bookmarks=Менеджер закладок
-termora.transport.bookmarks.up=Вверх
-termora.transport.bookmarks.down=Вниз
 
 termora.transport.toolbar.prev=Назад
 termora.transport.toolbar.home=Домашняя папка
 termora.transport.toolbar.next=Вперёд
 termora.transport.toolbar.parent=Родительская папка
-termora.transport.toolbar.show-hide=Показать/Скрыть папки
-termora.transport.toolbar.refresh=Обновить
+termora.transport.toolbar.show-hide=Показать или скрыть скрытые файлы и папки
+termora.transport.toolbar.refresh=Обновить папку
 
+termora.transport.bookmarks=Управление закладками
+termora.transport.bookmarks.add-current=Добавить текущую папку в закладки
+termora.transport.bookmarks.remove-current=Удалить текущую папку из закладок
+termora.transport.bookmarks.up=Вверх
+termora.transport.bookmarks.down=Вниз
 
 termora.transport.table.filename=Имя файла
 termora.transport.table.type=Тип
-termora.transport.table.type.symbolic-link=Символьная Ссылка
+termora.transport.table.type.symbolic-link=Символическая ссылка
 termora.transport.table.size=Размер
-termora.transport.table.modified-time=Измененный
-termora.transport.table.permissions=Разрешения
+termora.transport.table.modified-time=Дата изменения
+termora.transport.table.permissions=Права доступа
 termora.transport.table.owner=Владелец
 
 # contextmenu
-termora.transport.table.contextmenu.transfer=Файлы
+termora.transport.table.contextmenu.transfer=Передать
 termora.transport.table.contextmenu.edit=${termora.keymgr.edit}
-termora.transport.table.contextmenu.copy-path=Копировать Путь
+termora.transport.table.contextmenu.copy-path=Копировать путь
 termora.transport.table.contextmenu.open-in-folder=Открыть в {0}
 termora.transport.table.contextmenu.rename=${termora.welcome.contextmenu.rename}
 termora.transport.table.contextmenu.delete=${termora.remove}
-termora.transport.table.contextmenu.rm-warning=Использование команды rm -rf для удаления файла очень опасно.
-termora.transport.table.contextmenu.change-permissions=Изменить Разрешения...
+termora.transport.table.contextmenu.rm-warning=Удаление с помощью команды rm -rf может привести к безвозвратной потере данных. Вы уверены, что хотите продолжить?
+termora.transport.table.contextmenu.change-permissions=Изменить права доступа...
 termora.transport.table.contextmenu.refresh=Обновить
+termora.transport.table.contextmenu.compress=Сжать
+termora.transport.table.contextmenu.extract=Распаковать
+termora.transport.table.contextmenu.extract.here=Распаковать сюда
+termora.transport.table.contextmenu.extract.single=Распаковать в {0}\\
+termora.transport.table.contextmenu.extract.multi=Распаковать в *\\*
 termora.transport.table.contextmenu.new=${termora.welcome.contextmenu.new}
 termora.transport.table.contextmenu.new.folder=${termora.welcome.contextmenu.new.folder.name}
-termora.transport.table.contextmenu.new.file=Новый Файл
+termora.transport.table.contextmenu.new.file=Новый файл
 
 # Permission
-termora.transport.permissions=Изменить Разрешения
-termora.transport.permissions.file-folder-permissions=Файл/Папка Разрешения
-termora.transport.permissions.octal-mode=Восьмеричный режим
+termora.transport.permissions=Изменение прав доступа
+termora.transport.permissions.file-folder-permissions=Права доступа к файлу или папке
+termora.transport.permissions.octal-mode=Восьмеричный формат
 termora.transport.permissions.read=Чтение
 termora.transport.permissions.write=Запись
 termora.transport.permissions.execute=Выполнение
 termora.transport.permissions.owner=Владелец
 termora.transport.permissions.group=Группа
-termora.transport.permissions.others=Другие
-termora.transport.permissions.include-subfolder=Включая подкаталоги
+termora.transport.permissions.others=Остальные
+termora.transport.permissions.include-subfolder=Применить ко вложенным папкам
 
+termora.transport.sftp=Передача файлов
 termora.transport.sftp.retry=Повторить
 termora.transport.sftp.select-another-host=Выбрать другой хост
 termora.transport.sftp.select-host=Выбрать хост
-termora.transport.sftp.connecting=Соединение...
+termora.transport.sftp.connecting=Подключение...
 termora.transport.sftp.closed=Соединение закрыто
-termora.transport.sftp.close-tab=Передача все еще находится в активированном состоянии. Вы уверены, что хотите удалить все задания и закрыть этот сеанс?
-termora.transport.sftp.close-tab-has-active-session=Сессия все еще активна. Вы хотите закрыть все сессии?
-termora.transport.sftp.status.transporting=В процессе
+termora.transport.sftp.close-tab=Передача файлов ещё не завершена. Удалить все задания и закрыть этот сеанс?
+termora.transport.sftp.close-tab-has-active-session=Сеанс ещё активен. Закрыть все сеансы?
+termora.transport.sftp.status.transporting=Выполняется
+termora.transport.sftp.status.deleting=Удаление
 termora.transport.sftp.status.waiting=Ожидание
-termora.transport.sftp.status.done=Готово
+termora.transport.sftp.status.done=Завершено
 termora.transport.sftp.status.failed=Ошибка
 
-termora.transport.sftp.already-exists.message1=В этой папке уже содержится объект с указанным ниже именем.
-termora.transport.sftp.already-exists.message2=Выберите задачу для выполнения
-termora.transport.sftp.already-exists.overwrite=Перезаписать
-termora.transport.sftp.already-exists.append=Добавить
+termora.transport.sftp.already-exists.message1=В этой папке уже есть объект с указанным ниже именем
+termora.transport.sftp.already-exists.message2=Выберите действие
+termora.transport.sftp.already-exists.overwrite=Заменить
+termora.transport.sftp.already-exists.append=Дополнить
 termora.transport.sftp.already-exists.skip=Пропустить
-termora.transport.sftp.already-exists.apply-all=Применить все
-termora.transport.sftp.already-exists.name=Название
+termora.transport.sftp.already-exists.apply-all=Применить ко всем
+termora.transport.sftp.already-exists.name=Имя
 termora.transport.sftp.already-exists.destination=Назначение
 termora.transport.sftp.already-exists.source=Источник
 termora.transport.sftp.already-exists.actions=Действие
 
-
 # transport job
-termora.transport.jobs.table.name=Название
-termora.transport.jobs.table.status=Статус
-termora.transport.jobs.table.progress=Прогресс
+termora.transport.jobs.table.name=Имя
+termora.transport.jobs.table.status=Состояние
+termora.transport.jobs.table.progress=Ход выполнения
 termora.transport.jobs.table.size=Размер
-termora.transport.jobs.table.source-path=Путь Источника
-termora.transport.jobs.table.target-path=Путь Назначения
+termora.transport.jobs.table.source-path=Исходный путь
+termora.transport.jobs.table.target-path=Конечный путь
 termora.transport.jobs.table.speed=Скорость
-termora.transport.jobs.table.estimated-time=Расчетное время
-termora.transport.jobs.table.estimated-time-days-format={0}д {1}ч {2}м {3}с
-termora.transport.jobs.table.estimated-time-hours-format={0}ч {1}м {2}с
-termora.transport.jobs.table.estimated-time-minutes-format={0}м {1}с
-termora.transport.jobs.table.estimated-time-seconds-format={0}с
+termora.transport.jobs.table.estimated-time=Оставшееся время
+termora.transport.jobs.table.estimated-time-days-format={0} д {1} ч {2} мин {3} с
+termora.transport.jobs.table.estimated-time-hours-format={0} ч {1} мин {2} с
+termora.transport.jobs.table.estimated-time-minutes-format={0} мин {1} с
+termora.transport.jobs.table.estimated-time-seconds-format={0} с
 
 termora.transport.jobs.contextmenu.delete=${termora.remove}
-termora.transport.jobs.contextmenu.delete-all=Удалить Все
+termora.transport.jobs.contextmenu.delete-all=Удалить всё
 
 # ToolBar
-termora.toolbar.customize-toolbar=Настроить Панель Инструментов...
-
+termora.toolbar.customize-toolbar=Настроить панель инструментов...
 
 # Actions
-termora.actions.copy-from-terminal=Копировать из Терминала
+termora.actions.copy-from-terminal=Копировать из терминала
 termora.actions.focus-mode=Режим фокусировки
-termora.actions.paste-to-terminal=Вставить в Терминала
-termora.actions.select-all-in-terminal=Выделить Все в Терминале
-termora.actions.open-terminal-find=Открыть Поиск Терминала
-termora.actions.close-tab=Закрыть Вкладку
-termora.actions.zoom-in-terminal=Увеличить Терминал
-termora.actions.zoom-out-terminal=Уменьшить Терминал
-termora.actions.zoom-reset-terminal=Сброс Масштаба Терминала
-termora.actions.open-local-terminal=Открыть Локальный Терминал
-termora.actions.open-find-everywhere=Открыть ПоискВезде
-termora.actions.open-new-window=Открыть новое Окно
-termora.actions.clear-screen=Очистить Экран Терминала
-termora.actions.open-sftp-command=Открыть SFTP Команду
-termora.actions.switch-tab=Переключить на особую Вкладку [1..9]
+termora.actions.paste-to-terminal=Вставить в терминал
+termora.actions.select-all-in-terminal=Выделить всё в терминале
+termora.actions.open-terminal-find=Открыть поиск в терминале
+termora.actions.close-tab=Закрыть вкладку
+termora.actions.zoom-in-terminal=Увеличить масштаб терминала
+termora.actions.zoom-out-terminal=Уменьшить масштаб терминала
+termora.actions.zoom-reset-terminal=Сбросить масштаб терминала
+termora.actions.open-local-terminal=Открыть локальный терминал
+termora.actions.quick-connect=Быстрое подключение
+termora.actions.open-find-everywhere=Открыть поиск повсюду
+termora.actions.open-new-window=Открыть новое окно
+termora.actions.clear-screen=Очистить экран терминала
+termora.actions.open-sftp-command=Открыть терминал SFTP
+termora.actions.switch-tab=Переключиться на вкладку [1–9]
 
 # Terminal
-termora.terminal.size=Размер: {0} x {1}
+termora.terminal.size=Размер: {0} × {1}
 termora.terminal.copied=Скопировано
-termora.terminal.channel-disconnected=Канал был отключен.\u0020
-termora.terminal.channel-reconnect=Введите {0} для повторного подключения.
+termora.terminal.channel-disconnected=Соединение разорвано.\u0020
+termora.terminal.channel-reconnect=Нажмите {0}, чтобы переподключиться.
+
+# protocol
+termora.protocol.not-supported=Протокол {0} не поддерживается. Возможно, необходимо установить плагин
+termora.vnc.error.authentication-failed=Не удалось пройти аутентификацию VNC
+termora.vnc.error.unsupported-protocol=VNC-сервер использует неподдерживаемую версию протокола
+termora.vnc.error.unsupported-security=VNC-сервер использует неподдерживаемый тип защиты
+termora.vnc.error.timeout=Истекло время ожидания подключения к VNC-серверу
+termora.vnc.error.unknown-host=Не удалось определить адрес VNC-сервера
+termora.vnc.error.connection-failed=Не удалось подключиться к VNC-серверу
+termora.vnc.error.generic=При подключении к VNC-серверу произошла ошибка
+termora.ssh.user-authentication=Аутентификация пользователя SSH
+termora.find-everywhere.nothing-found=Ничего не найдено
+
+# Object storage
+termora.object-storage.endpoint=Конечная точка
+termora.object-storage.access-key=Ключ доступа
+termora.object-storage.secret-id=Идентификатор доступа
+termora.object-storage.secret-key=Секретный ключ
+termora.object-storage.region=Регион
+termora.object-storage.delimiter=Разделитель
 
 # Visual Window
-termora.visual-window.system-information=Системная информация
+termora.visual-window.system-information=Сведения о системе
+termora.visual-window.system-information.cpu=Процессор
 termora.visual-window.system-information.mem=Память
-termora.visual-window.system-information.swap=Подкачка
+termora.visual-window.system-information.swap=Файл подкачки
 termora.visual-window.system-information.filesystem=Файловая система
-termora.visual-window.system-information.used-total=Использовано / Всего
-termora.visual-window.toggle-window=Переключить окно
-termora.visual-window.transport.question=Больше возможностей
+termora.visual-window.system-information.used-total=Использовано / всего
+termora.visual-window.toggle-window=Показать или скрыть окно
+termora.visual-window.open-in-new-window=Открыть в отдельном окне
+termora.visual-window.return-to-panel=Вернуть в панель
+termora.visual-window.transport.question=Дополнительные возможности
 
-
-termora.visual-window.command-history=История командования
+termora.visual-window.command-history=История команд
 
 termora.visual-window.nvidia-smi=NVIDIA SMI
-
+termora.visual-window.nvidia-smi.gpu=Графический процессор
+termora.visual-window.nvidia-smi.temperature=Температура
+termora.visual-window.nvidia-smi.memory=Память
+termora.visual-window.nvidia-smi.power=Мощность
+termora.visual-window.nvidia-smi.driver=Драйвер
+termora.visual-window.nvidia-smi.gpus=Графические процессоры
 
 termora.floating-toolbar.close-in-current-tab=Закрыть в текущей вкладке
 
-
 # zmodem
-termora.addons.zmodem.skip=ПРОПУСК
+termora.addons.zmodem.skip=ПРОПУСТИТЬ

--- a/src/main/resources/i18n/messages_zh_CN.properties
+++ b/src/main/resources/i18n/messages_zh_CN.properties
@@ -308,6 +308,8 @@ termora.transport.local=本机
 termora.transport.file-already-exists=文件 {0} 已存在
 
 termora.transport.bookmarks=书签管理
+termora.transport.bookmarks.add-current=将当前文件夹添加到书签
+termora.transport.bookmarks.remove-current=从书签中移除当前文件夹
 termora.transport.bookmarks.up=上移
 termora.transport.bookmarks.down=下移
 

--- a/src/main/resources/i18n/messages_zh_TW.properties
+++ b/src/main/resources/i18n/messages_zh_TW.properties
@@ -304,6 +304,8 @@ termora.transport.local=本機
 termora.transport.file-already-exists=檔案 {0} 已存在
 
 termora.transport.bookmarks=書籤管理
+termora.transport.bookmarks.add-current=將目前資料夾加入書籤
+termora.transport.bookmarks.remove-current=從書籤中移除目前資料夾
 termora.transport.bookmarks.up=上移
 termora.transport.bookmarks.down=下移
 


### PR DESCRIPTION
# ⚠️ Required merge order

> [!WARNING]
> **Please merge [TermoraDev/termora-marketplace#2](https://github.com/TermoraDev/termora-marketplace/pull/2) before merging this PR.**
>
> This PR publishes new plugin versions from the Termora 2.x codebase, which now requires Java 25. The current marketplace publishing workflow cannot build those plugins until marketplace PR #2 updates its build stack to Java 25.

---

## Summary

- completed and improved the Russian interface localization
- translated previously untranslated plugin descriptions, migration UI, Sync settings, dialogs, and status messages
- improved terminology for Highlight Sets and Snippets
- updated the Russian README
- fixed monospace font selection to preserve terminal and ASCII-art rendering
- widened the settings dialog to prevent Russian labels from being clipped

## Testing

- built and manually tested the application on Windows and MacOS
- checked the Russian interface, terminal output, ASCII banners, plugin settings, and settings dialog layout

## Notes

The changes are split into three commits:

1. Russian localization improvements
2. Terminal font and ASCII rendering fixes
3. Settings dialog width fix
