### PR TITLE
fix: parse system information independently of server locale

### DIFF
--- a/src/main/kotlin/app/termora/terminal/panel/vw/SystemInformationVisualWindow.kt
+++ b/src/main/kotlin/app/termora/terminal/panel/vw/SystemInformationVisualWindow.kt
@@ -142,8 +142,8 @@ internal class SystemInformationVisualWindow(tab: SSHTerminalTab, visualWindowMa
 
         private suspend fun refreshCPUAndMem(session: ClientSession) {
 
-            // top
-            val pair = SshClients.execChannel(session, "top -bn1")
+            // Keep labels and decimal separators stable for the parser regardless of the server locale.
+            val pair = SshClients.execChannel(session, "LC_ALL=C top -bn1")
             if (pair.first != 0) {
                 return
             }


### PR DESCRIPTION
## Summary

- force the `C` locale for the remote `top` command
- keep labels and decimal separators stable for the existing parser
- prevent localized decimal commas from being interpreted as field separators

Fixes #1545.

## Reproduction

On Debian with `LANG=ru_RU.UTF-8`, `top -bn1` returns values such as:

```text
%Cpu(s):  0,9 us,  0,9 sy,  0,0 ni, 98,2 id
MiB Mem : 15832,1 total, 11619,0 free, 2776,8 used
```

The parser splits these lines on commas, so it reads `2` as idle CPU, `1` as total memory, and `8` as used memory. This produces values such as 98% CPU and 8 MB / 1 MB RAM.

`LC_ALL=C top -bn1` produces the locale-independent format expected by the parser.

## Verification

The system information panel now matches the values reported by `btop` on the same Debian host:

![System information values after the locale-independent parsing fix](https://raw.githubusercontent.com/halsatif/termoradev/pr-assets/.github/pr-assets/1601-system-info-verification.png)

## Testing

- verified on Windows 11
- verified the command against Debian with procps-ng 4.0.4 and `LANG=ru_RU.UTF-8`
- `./gradlew.bat compileKotlin` with Java 25
- `git diff --check`

The complete test suite was also run; its existing Docker-dependent tests and `HostConfigEntryTest` could not pass in the local environment.