### PR TITLE
feat: add UI scale option to appearance settings

### DIFF
--- a/src/main/kotlin/app/termora/Application.kt
+++ b/src/main/kotlin/app/termora/Application.kt
@@ -27,6 +27,11 @@ import kotlin.math.pow
 object Application {
     private lateinit var baseDataDir: File
 
+    /**
+     * 标记 flatlaf.uiScale 是由设置界面写入的，而非 JVM 参数或环境变量
+     */
+    const val UI_SCALE_FROM_SETTINGS = "termora.uiScale.fromSettings"
+
 
     val ohMyJson = Json {
         ignoreUnknownKeys = true

--- a/src/main/kotlin/app/termora/ApplicationRunner.kt
+++ b/src/main/kotlin/app/termora/ApplicationRunner.kt
@@ -209,6 +209,7 @@ class ApplicationRunner {
         ) {
             System.setProperty(FlatSystemProperties.UI_SCALE_ENABLED, "true")
             System.setProperty(FlatSystemProperties.UI_SCALE, uiScale)
+            System.setProperty(Application.UI_SCALE_FROM_SETTINGS, "true")
         }
     }
 

--- a/src/main/kotlin/app/termora/ApplicationRunner.kt
+++ b/src/main/kotlin/app/termora/ApplicationRunner.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.launch
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.LocaleUtils
 import org.apache.commons.lang3.SystemUtils
+import org.apache.commons.lang3.math.NumberUtils
 import org.slf4j.LoggerFactory
 import java.awt.*
 import java.awt.desktop.AppReopenedEvent
@@ -200,6 +201,15 @@ class ApplicationRunner {
             log.info("Language: {} , Locale: {}", language, locale)
         }
         Locale.setDefault(locale)
+
+        // UI 缩放，仅在未被 JVM 参数或 TERMORA_SCALE 环境变量覆盖时生效
+        val uiScale = DatabaseManager.getInstance().appearance.uiScale
+        if (System.getProperty(FlatSystemProperties.UI_SCALE).isNullOrBlank()
+            && NumberUtils.toDouble(uiScale, -1.0) > 0
+        ) {
+            System.setProperty(FlatSystemProperties.UI_SCALE_ENABLED, "true")
+            System.setProperty(FlatSystemProperties.UI_SCALE, uiScale)
+        }
     }
 
 

--- a/src/main/kotlin/app/termora/SettingsOptionsPane.kt
+++ b/src/main/kotlin/app/termora/SettingsOptionsPane.kt
@@ -239,7 +239,9 @@ class SettingsOptionsPane : OptionsPane() {
                 }
             }
 
-            if (System.getProperty(FlatSystemProperties.UI_SCALE).isNullOrBlank().not()) {
+            if (System.getProperty(FlatSystemProperties.UI_SCALE).isNullOrBlank().not()
+                && System.getProperty(Application.UI_SCALE_FROM_SETTINGS) == null
+            ) {
                 uiScaleComboBox.isEnabled = false
                 uiScaleComboBox.toolTipText = I18n.getString("termora.settings.appearance.ui-scale.overridden")
             }

--- a/src/main/kotlin/app/termora/SettingsOptionsPane.kt
+++ b/src/main/kotlin/app/termora/SettingsOptionsPane.kt
@@ -12,6 +12,7 @@ import app.termora.terminal.panel.FloatingToolbarPanel
 import app.termora.terminal.panel.TerminalPanel
 import app.termora.transfer.TransportTerminalTab
 import com.formdev.flatlaf.FlatClientProperties
+import com.formdev.flatlaf.FlatSystemProperties
 import com.formdev.flatlaf.extras.components.FlatComboBox
 import com.formdev.flatlaf.extras.components.FlatPopupMenu
 import com.formdev.flatlaf.extras.components.FlatToolBar
@@ -116,6 +117,7 @@ class SettingsOptionsPane : OptionsPane() {
         val backgroundComBoBox = YesOrNoComboBox()
         val confirmTabCloseComBoBox = YesOrNoComboBox()
         val tabOrderComboBox = FlatComboBox<TabOrder>()
+        val uiScaleComboBox = FlatComboBox<String>()
         val followSystemCheckBox = JCheckBox(I18n.getString("termora.settings.appearance.follow-system"))
         val preferredThemeBtn = JButton(Icons.settings)
         val opacitySpinner = NumberSpinner(100, 0, 100)
@@ -213,6 +215,35 @@ class SettingsOptionsPane : OptionsPane() {
                 }
             }
 
+            val scales = listOf("1.0", "1.25", "1.5", "1.75", "2.0", "2.5", "3.0")
+            scales.forEach { uiScaleComboBox.addItem(it) }
+            val uiScale = appearance.uiScale
+            if (uiScale.isNotBlank() && uiScale !in scales) {
+                uiScaleComboBox.addItem(uiScale)
+            }
+            uiScaleComboBox.selectedItem = uiScale
+            uiScaleComboBox.renderer = object : DefaultListCellRenderer() {
+                override fun getListCellRendererComponent(
+                    list: JList<*>?,
+                    value: Any?,
+                    index: Int,
+                    isSelected: Boolean,
+                    cellHasFocus: Boolean
+                ): Component {
+                    val text = if (value == null || value == StringUtils.EMPTY) {
+                        I18n.getString("termora.settings.appearance.ui-scale.system")
+                    } else {
+                        "${((value.toString().toDoubleOrNull() ?: 1.0) * 100).toInt()}%"
+                    }
+                    return super.getListCellRendererComponent(list, text, index, isSelected, cellHasFocus)
+                }
+            }
+
+            if (System.getProperty(FlatSystemProperties.UI_SCALE).isNullOrBlank().not()) {
+                uiScaleComboBox.isEnabled = false
+                uiScaleComboBox.toolTipText = I18n.getString("termora.settings.appearance.ui-scale.overridden")
+            }
+
             add(getFormPanel(), BorderLayout.CENTER)
         }
 
@@ -292,6 +323,14 @@ class SettingsOptionsPane : OptionsPane() {
                 }
             }
 
+            uiScaleComboBox.addItemListener(object : ItemListener {
+                override fun itemStateChanged(e: ItemEvent) {
+                    if (e.stateChange != ItemEvent.SELECTED) return
+                    appearance.uiScale = uiScaleComboBox.selectedItem?.toString() ?: return
+                    SwingUtilities.invokeLater { TermoraRestarter.getInstance().scheduleRestart(owner) }
+                }
+            })
+
             preferredThemeBtn.addActionListener { showPreferredThemeContextmenu() }
 
         }
@@ -366,8 +405,9 @@ class SettingsOptionsPane : OptionsPane() {
         private fun getFormPanel(): JPanel {
             val layout = FormLayout(
                 "left:pref, $FORM_MARGIN, default:grow, $FORM_MARGIN, default, default:grow",
-                "pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref"
+                "pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref, $FORM_MARGIN, pref"
             )
+
             val box = FlatToolBar()
             box.add(followSystemCheckBox)
             box.add(Box.createHorizontalStrut(2))
@@ -390,6 +430,9 @@ class SettingsOptionsPane : OptionsPane() {
 
             builder.add("${I18n.getString("termora.settings.appearance.layout")}:").xy(1, rows)
                 .add(layoutComboBox).xy(3, rows).apply { rows += step }
+
+            builder.add("${I18n.getString("termora.settings.appearance.ui-scale")}:").xy(1, rows)
+                .add(uiScaleComboBox).xy(3, rows).apply { rows += step }
 
             builder.add("${I18n.getString("termora.settings.appearance.opacity")}:").xy(1, rows)
                 .add(opacitySpinner).xy(3, rows).apply { rows += step }

--- a/src/main/kotlin/app/termora/database/DatabaseManager.kt
+++ b/src/main/kotlin/app/termora/database/DatabaseManager.kt
@@ -761,6 +761,11 @@ class DatabaseManager private constructor() : Disposable {
          * 透明度
          */
         var opacity by DoublePropertyDelegate(1.0)
+
+        /**
+         * UI 缩放，空表示跟随系统默认
+         */
+        var uiScale by StringPropertyDelegate(StringUtils.EMPTY)
     }
 
     /**

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -47,6 +47,9 @@ termora.settings.appearance.opacity=Opacity
 termora.settings.appearance.background-running=Backgrounding
 termora.settings.appearance.tab-order=Tab Order
 termora.settings.appearance.confirm-tab-close=Confirm tab close
+termora.settings.appearance.ui-scale=UI Scale
+termora.settings.appearance.ui-scale.system=System
+termora.settings.appearance.ui-scale.overridden=UI scale is overridden by JVM argument or TERMORA_SCALE environment variable
 
 termora.settings.terminal=Terminal
 termora.settings.terminal.font=Font

--- a/src/main/resources/i18n/messages_de_DE.properties
+++ b/src/main/resources/i18n/messages_de_DE.properties
@@ -47,6 +47,9 @@ termora.settings.appearance.opacity=Deckkraft
 termora.settings.appearance.background-running=Im Hintergrund weiterlaufen
 termora.settings.appearance.tab-order=Tab-Reihenfolge
 termora.settings.appearance.confirm-tab-close=Vor dem Schließen von Tabs nachfragen
+termora.settings.appearance.ui-scale=UI-Skalierung
+termora.settings.appearance.ui-scale.system=Systemstandard
+termora.settings.appearance.ui-scale.overridden=Die UI-Skalierung wird durch ein JVM-Argument oder die Umgebungsvariable TERMORA_SCALE überschrieben
 
 termora.settings.terminal=Terminal
 termora.settings.terminal.font=Schriftart

--- a/src/main/resources/i18n/messages_pt_BR.properties
+++ b/src/main/resources/i18n/messages_pt_BR.properties
@@ -47,6 +47,9 @@ termora.settings.appearance.opacity=Opacidade
 termora.settings.appearance.background-running=Execução em segundo plano
 termora.settings.appearance.tab-order=Ordem das Abas
 termora.settings.appearance.confirm-tab-close=Confirmar fechamento de aba
+termora.settings.appearance.ui-scale=Escala da interface
+termora.settings.appearance.ui-scale.system=Sistema
+termora.settings.appearance.ui-scale.overridden=A escala da interface foi substituída por um argumento JVM ou pela variável de ambiente TERMORA_SCALE
 
 termora.settings.terminal=Terminal
 termora.settings.terminal.font=Fonte

--- a/src/main/resources/i18n/messages_ru_RU.properties
+++ b/src/main/resources/i18n/messages_ru_RU.properties
@@ -42,6 +42,9 @@ termora.settings.appearance.background-image=Фоновое изображени
 termora.settings.appearance.background-running=Фон
 termora.settings.appearance.tab-order=Порядок вкладок
 termora.settings.appearance.confirm-tab-close=Подтверждение закрытия вкладки
+termora.settings.appearance.ui-scale=Масштаб интерфейса
+termora.settings.appearance.ui-scale.system=Системный
+termora.settings.appearance.ui-scale.overridden=Масштаб интерфейса переопределён аргументом JVM или переменной окружения TERMORA_SCALE
 
 termora.setting.security=Безопасность
 termora.setting.security.enter-password=Введите пароль

--- a/src/main/resources/i18n/messages_zh_CN.properties
+++ b/src/main/resources/i18n/messages_zh_CN.properties
@@ -51,6 +51,9 @@ termora.settings.appearance.opacity=透明度
 termora.settings.appearance.background-running=后台运行
 termora.settings.appearance.tab-order=标签序号
 termora.settings.appearance.confirm-tab-close=标签关闭前确认
+termora.settings.appearance.ui-scale=界面缩放
+termora.settings.appearance.ui-scale.system=跟随系统
+termora.settings.appearance.ui-scale.overridden=界面缩放已被 JVM 参数或 TERMORA_SCALE 环境变量覆盖
 
 # Find everywhere
 termora.find-everywhere=查找

--- a/src/main/resources/i18n/messages_zh_TW.properties
+++ b/src/main/resources/i18n/messages_zh_TW.properties
@@ -50,6 +50,9 @@ termora.settings.appearance.opacity=透明度
 termora.settings.appearance.background-running=後台運行
 termora.settings.appearance.tab-order=標籤序號
 termora.settings.appearance.confirm-tab-close=關閉分頁確認
+termora.settings.appearance.ui-scale=介面縮放
+termora.settings.appearance.ui-scale.system=跟隨系統
+termora.settings.appearance.ui-scale.overridden=介面縮放已被 JVM 參數或 TERMORA_SCALE 環境變數覆蓋
 
 termora.settings.keymap=鍵盤
 termora.settings.keymap.shortcut=快捷鍵


### PR DESCRIPTION
## Problem

On high-DPI displays — especially on Linux, where the JVM/FlatLaf may not pick up the desktop scale factor correctly — the UI controls (buttons, menus, toolbar icons) render extremely small and are hard to use.

Termora already supports a hidden environment variable `TERMORA_SCALE` (applied as `flatlaf.uiScale` in `ApplicationInitializr`), but it requires launching from a terminal and is undiscoverable for regular users.

## Solution

Add a **UI Scale** dropdown to Settings → General:

- Options: **System** (default, current behavior) / 100% / 125% / 150% / 175% / 200% / 250% / 300%
- Persisted in the database (`Setting.Appearance.uiScale`) and applied at startup in `ApplicationRunner#loadSettings`, before FlatLaf initializes the look and feel
- Switching prompts for a restart (same flow as language switching)
- Priority: `-Dflatlaf.uiScale` JVM argument > `TERMORA_SCALE` environment variable > this setting. When overridden externally the dropdown is disabled with an explanatory tooltip
- i18n updated for all 6 supported languages (en, zh_CN, zh_TW, de_DE, pt_BR, ru_RU)

## Screenshots

Screenshots will be attached below.
